### PR TITLE
🐛 fix : Image 에서 InputStream 이 아닌 byte[] 를 사용하여 이미지 컨텐츠 저장하는 방식으로 변경

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/Image.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/Image.java
@@ -1,11 +1,10 @@
 package com.devcourse.eggmarket.domain.model.image;
 
-import java.io.InputStream;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface Image {
 
-    InputStream getContents();
+    byte[] getContents();
 
     String pathTobeStored(String basePath);
 

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/LocalImageUpload.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/LocalImageUpload.java
@@ -25,7 +25,7 @@ public class LocalImageUpload implements ImageUpload {
         String path = imgPath(image);
 
         try {
-            FileUtils.copyInputStreamToFile(image.getContents(), new File(path));
+            FileUtils.writeByteArrayToFile(new File(path), image.getContents());
         } catch (IOException e) {
             throw new ImageFileUploadException(e);
         }

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImage.java
@@ -11,26 +11,26 @@ public class PostImage implements Image {
     private static final String DELIMITER = "_";
     private static final String EXTENSION_SEPARATOR = ".";
     private final ImageType type;
-    private final InputStream inputStream;
+    private final byte[] bytes;
     private final String fileName;
     private final String extension;
     private final int order; // 이미지 순서
     private final long id; // 판매글 id
 
-    private PostImage(ImageType type, InputStream inputStream, String extension, int order,
+    private PostImage(ImageType type, byte[] bytes, String extension, int order,
         String fileName,
         long id) {
         this.type = type;
-        this.inputStream = inputStream;
+        this.bytes = bytes;
         this.extension = extension;
         this.fileName = fileName;
         this.order = order;
         this.id = id;
     }
 
-    private PostImage(ImageType type, InputStream inputStream, int order, String fileName,
+    private PostImage(ImageType type, byte[] bytes, int order, String fileName,
         long id) {
-        this(type, inputStream, FilenameUtils.getExtension(fileName), order, fileName, id);
+        this(type, bytes, FilenameUtils.getExtension(fileName), order, fileName, id);
     }
 
     public static PostImage toImage(long postId, MultipartFile file, int img_order) {
@@ -39,7 +39,8 @@ public class PostImage implements Image {
         }
 
         try (InputStream inputStream = file.getInputStream()) {
-            return new PostImage(ImageType.POST, inputStream, img_order, file.getOriginalFilename(),
+            return new PostImage(ImageType.POST, inputStream.readAllBytes(), img_order,
+                file.getOriginalFilename(),
                 postId);
         } catch (IOException e) {
             throw new InvalidFileException("판매글에 업로드된 파일을 읽어오는데 실패하였습니다", e);
@@ -47,8 +48,8 @@ public class PostImage implements Image {
     }
 
     @Override
-    public InputStream getContents() {
-        return this.inputStream;
+    public byte[] getContents() {
+        return this.bytes;
     }
 
     @Override

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImage.java
@@ -1,12 +1,10 @@
 package com.devcourse.eggmarket.domain.model.image;
 
-import java.io.InputStream;
-
 public class ProfileImage implements Image {
 	// TODO : 필요한 필드
 
 	@Override
-	public InputStream getContents() {
+	public byte[] getContents() {
 		// TODO : 구현 부탁드려요
 		return null;
 	}


### PR DESCRIPTION
## 🧑‍💻 작업사항
- InputStream is closed 으로 인한 에러 발생하여 byte[] 를 사용하여 메모리에 일시적으로 저장하는 방식을 택하였음
- 기존 이슈 : Inputstream is closed 로 인한 예외 발생

## 작업으로 인해 해결된 이슈 번호
- EM-57
