### PR TITLE
🐛 fix : 배포중 프로세스가 종료되지 않는 현상 수정

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -11,5 +11,5 @@ NOW=$(date +%c)
 echo "[$NOW] 애플리케이션 실행" >>$DEPLOY_LOG
 nohup java -jar $JAR_FILE &
 
-RUNNING_PID=$(pgrep -f $PROJECT_NAME-$PROJECT_VERSION)
+RUNNING_PID=$(pgrep -f $PROJECT_NAME)
 echo "[$NOW] 프로세스가 정상적으로 실행되었습니다. 실행 PID -> $RUNNING_PID" >>$DEPLOY_LOG

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 PROJECT_PATH="/home/ec2-user/egg-market"
 PROJECT_NAME="eggmarket"
-PROJECT_VERSION="0.0.1-SNAPSHOT"
 DEPLOY_LOG="$PROJECT_PATH/deploy.log"
 
-RUNNING_PID=$(pgrep -f $PROJECT_NAME-$PROJECT_VERSION)
+RUNNING_PID=$(pgrep -f $PROJECT_NAME)
 
 NOW=$(date +%c)
 
-if [ -z "$CUREENT_PID" ]; then
+if [ -z "$RUNNING_PID" ]; then
   echo "[$NOW] 현재 실행중인 애플리케이션이 없습니다." >>$DEPLOY_LOG
 else
   echo "[$NOW] 실행중인 $RUNNING_PID 애플리케이션을 종료합니다." >> $DEPLOY_LOG


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 변수명을 잘못 비교하여 애플리케이션이 정상적으로 종료되지 않는 현상이 발생
  - 종료 쉘 스크립트의 변수명 수정하여 해결
  - 현재 프로세스 체크를 프로젝트 이름으로만 하도록 변경

## 이슈 번호
- [EM-41](https://hkasdasdq.atlassian.net/browse/EM-41)