### PR TITLE
✨ feat : 판매글 내용 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -5,6 +5,8 @@ import com.devcourse.eggmarket.domain.post.service.PostService;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,4 +36,12 @@ public class PostController {
             .body(postId);
     }
 
+    @PatchMapping("{id}")
+    ResponseEntity<Long> update(@RequestBody PostRequest.UpdatePost request,
+        Authentication authentication,
+        @PathVariable Long id) {
+        Long postId = postService.updatePost(id, request, authentication.getName());
+
+        return ResponseEntity.ok(postId);
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -1,6 +1,7 @@
 package com.devcourse.eggmarket.domain.post.converter;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePost;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.user.model.User;
@@ -17,5 +18,12 @@ public class PostConverter {
             .price(request.price())
             .seller(seller)
             .build();
+    }
+
+    public void updateToPost(PostRequest.UpdatePost request, Post post) {
+        post.updateTitle(request.title());
+        post.updateContent(request.content());
+        post.updatePrice(request.price());
+        post.updateCategory(Category.valueOf(request.category()));
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/exception/NotExistPostException.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/exception/NotExistPostException.java
@@ -1,0 +1,10 @@
+package com.devcourse.eggmarket.domain.post.exception;
+
+import com.devcourse.eggmarket.global.error.exception.EntityNotFoundException;
+
+public class NotExistPostException extends EntityNotFoundException {
+
+    public NotExistPostException(String message, Long id) {
+        super(message + id);
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/exception/NotMatchedSellerException.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/exception/NotMatchedSellerException.java
@@ -1,0 +1,10 @@
+package com.devcourse.eggmarket.domain.post.exception;
+
+import com.devcourse.eggmarket.global.error.exception.InvalidValueException;
+
+public class NotMatchedSellerException extends InvalidValueException {
+
+    public NotMatchedSellerException(String value, Long sellerId, Long loginId) {
+        super(value + sellerId + loginId);
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/exception/PostExceptionMessage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/exception/PostExceptionMessage.java
@@ -34,4 +34,8 @@ public class PostExceptionMessage {
     public static final String NOT_VALID_CATEGORY = "잘못 된 카테고리 입니다";
 
     public static final String NOT_VALID_POST_STATUS = "잘못 된 판매 상태 입니다";
+
+    public static final String NOT_EXIST_POST = "존재하지 않는 판매글 입니다. 조회한 판매글 번호 : ";
+
+    public static final String NOT_MATCHED_SELLER_POST = "판매자와 로그인 유저가 다릅니다. 판매자, 로그인 유저 : ";
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -11,7 +11,7 @@ public interface PostService {
 
     Long save(Save request, String loginUser);
 
-    Long updatePost(Long id, PostRequest.UpdatePost request);
+    Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser);
 
     Long updatePurchaseInfo(PostRequest.UpdatePurchaseInfo request);
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -1,14 +1,20 @@
 package com.devcourse.eggmarket.domain.post.service;
 
+import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage.NOT_EXIST_POST;
+import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage.NOT_MATCHED_SELLER_POST;
+
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
+import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,8 +47,16 @@ public class PostServiceImpl implements PostService {
 
     @Transactional
     @Override
-    public Long updatePost(Long id, PostRequest.UpdatePost request) {
-        return null;
+    public Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser) {
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, id));
+        Long loginUserId = userService.getUser(loginUser).getId();
+        Long sellerId = post.getSeller().getId();
+        if (!(sellerId.equals(loginUserId))) {
+            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, sellerId, loginUserId);
+        }
+        postConverter.updateToPost(request, post);
+        return post.getId();
     }
 
     @Transactional

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -1,18 +1,27 @@
 package com.devcourse.eggmarket.domain.post.service;
 
+import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage.NOT_EXIST_POST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.in;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
-import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
-import com.devcourse.eggmarket.domain.post.model.Category;
+import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
+import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
+import com.devcourse.eggmarket.domain.stub.PostStub;
+import com.devcourse.eggmarket.domain.stub.UserStub;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,24 +44,14 @@ class PostServiceImplTest {
     @Mock
     PostRepository postRepository;
 
+    //TODO 엔티티를 생성하고 ID가 자동으로 할당되지 않아 null 값이 반환되어 id 값의 비교가 불가능
     @Test
     @DisplayName("판매글 생성 테스트")
     void saveTest() {
-        PostRequest.Save request = new Save("title", "content", 1000, "BEAUTY");
+        PostRequest.Save request = PostStub.writeRequest();
         String loginUser = "test";
-        User seller = User.builder()
-            .nickName("test")
-            .password("asdfg123!@")
-            .phoneNumber("01000000000")
-            .role("USER")
-            .build();
-        Post want = Post.builder()
-            .title("title")
-            .content("content")
-            .price(1000)
-            .category(Category.BEAUTY)
-            .seller(seller)
-            .build();
+        User seller = UserStub.entity();
+        Post want = PostStub.entity(seller);
 
         doReturn(seller)
             .when(userService)
@@ -64,6 +63,72 @@ class PostServiceImplTest {
             .when(postRepository)
             .save(any(Post.class));
 
-        assertThat(postService.save(request, loginUser)).isEqualTo(want.getId());
+    assertThat(postService.save(request, loginUser)).isEqualTo(want.getId());
+}
+
+    //TODO 엔티티를 생성하고 ID가 자동으로 할당되지 않아 null 값이 반환되어 id 값의 비교가 불가능
+    @Test
+    @DisplayName("판매글 업데이트 테스트")
+    void updatePostTest() {
+//        PostRequest.UpdatePost request = PostStub.updatePostRequest();
+//        Long id = 1L;
+//        String loginUser = "test";
+//        User seller = UserStub.entity();
+//        Post post = PostStub.entity(seller);
+//        Post updatePost = PostStub.updatedEntity(seller);
+//
+//        doReturn(Optional.of(post))
+//            .when(postRepository)
+//            .findById(anyLong());
+//        doReturn(seller)
+//            .when(userService)
+//            .getUser(anyString());
+//        doNothing()
+//            .when(postConverter)
+//            .updateToPost(request, post);
+//
+//        assertThat(postService.updatePost(id, request, loginUser))
+//            .isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("판매글 업데이트시 전달받은 판매글 ID가 존재하지 않을 경우 예외 발생")
+    void updatePostInvalidIdTest() {
+        PostRequest.UpdatePost request = PostStub.updatePostRequest();
+        Long invalidId = -1L;
+        String loginUser = "test";
+
+        doThrow(new NotExistPostException(NOT_EXIST_POST, invalidId))
+            .when(postRepository)
+            .findById(invalidId);
+
+        assertThatExceptionOfType(NotExistPostException.class)
+            .isThrownBy(() -> postService.updatePost(invalidId, request, loginUser));
+    }
+
+    //TODO 엔티티를 생성하고 ID가 자동으로 할당되지 않아 null 값이 반환되어 id 값의 비교가 불가능
+    @Test
+    @DisplayName("현재 판매글의 판매자 ID와 로그인 사용자의 ID가 다른 경우 예외 발생")
+    void updatePostNotMatchedSellerTest() {
+//        PostRequest.UpdatePost request = PostStub.updatePostRequest();
+//        Long id = 1L;
+//        String loginUser = "test";
+//        Long sellerId = 1L;
+//        Long loginUserId = 2L;
+//        User seller = UserStub.entity();
+//        Post post = PostStub.entity(seller);
+//
+//        doReturn(Optional.of(post))
+//            .when(postRepository)
+//            .findById(anyLong());
+//        doReturn(seller)
+//            .when(userService)
+//            .getUser(anyString());
+//        doReturn(loginUserId)
+//            .when(post)
+//            .getId();
+
+//        assertThatExceptionOfType(NotMatchedSellerException.class)
+//            .isThrownBy(() -> postService.updatePost(id, request, loginUser));
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -1,0 +1,64 @@
+package com.devcourse.eggmarket.domain.stub;
+
+import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePost;
+import com.devcourse.eggmarket.domain.post.model.Category;
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.user.model.User;
+
+public class PostStub {
+
+    private PostStub() {
+
+    }
+
+    public static PostRequest.Save writeRequest() {
+        return new PostRequest.Save(
+            "title",
+            "content",
+            1000,
+            "BEAUTY"
+        );
+    }
+
+    public static PostRequest.Save invalidCategoryWriteRequest() {
+        return new PostRequest.Save(
+            "title",
+            "content",
+            1000,
+            "FOOD"
+        );
+    }
+
+    public static Post entity(User seller) {
+        return Post.builder()
+            .title("title")
+            .content("content")
+            .price(1000)
+            .category(Category.BEAUTY)
+            .seller(seller)
+            .build();
+    }
+
+    public static PostRequest.UpdatePost updatePostRequest() {
+        return new PostRequest.UpdatePost(
+            "update-title",
+            "update-content",
+            2000,
+            "DIGITAL"
+        );
+    }
+
+    public static Post updatedEntity(User seller) {
+        return Post.builder()
+            .title("update-title")
+            .content("update-content")
+            .price(2000)
+            .category(Category.DIGITAL)
+            .seller(seller)
+            .build();
+    }
+
+
+}
+

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
@@ -1,0 +1,18 @@
+package com.devcourse.eggmarket.domain.stub;
+
+import com.devcourse.eggmarket.domain.user.model.User;
+
+public class UserStub {
+
+    private UserStub() {
+    }
+
+    public static User entity() {
+        return User.builder()
+            .nickName("test")
+            .password("asdfg123!@")
+            .phoneNumber("01000000000")
+            .role("USER")
+            .build();
+    }
+}


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 내용을 업데이트할 수 있는 기능 추가
- 업데이트시 발생할 수 있는 커스텀 exception 추가
- 판매글 업데이트 관련 테스트 코드 추가 (TODO 존재)
- 판매글 테스트시 사용하는 stub 추가

## 이슈 번호
- [EM-19](https://hkasdasdq.atlassian.net/browse/EM-19)

## 문제 사항
- 엔티티의 ID 값이 실제로 증가하지 않아 null 들어가서 테스트를 어떻게 작성할지 해결하지 못했습니다. 이와 관련해서 해결방법을 아는 분은 공유 부탁드립니다.
- 테스트가 어려운 부분의 위에 TODO로 표시해 두었습니다.