### PR TITLE
✨ feat : 판매글 상태변경 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -37,11 +37,20 @@ public class PostController {
             .body(postId);
     }
 
-    @PatchMapping("{id}")
-    ResponseEntity<Long> update(@RequestBody PostRequest.UpdatePost request,
+    @PatchMapping("/{id}/post")
+    ResponseEntity<Long> updatePost(@RequestBody PostRequest.UpdatePost request,
         Authentication authentication,
         @PathVariable Long id) {
         Long postId = postService.updatePost(id, request, authentication.getName());
+
+        return ResponseEntity.ok(postId);
+    }
+
+    @PatchMapping("/{id}/purchase")
+    ResponseEntity<Long> updatePurchase(@RequestBody PostRequest.UpdatePurchaseInfo request,
+        Authentication authentication,
+        @PathVariable Long id) {
+        Long postId = postService.updatePurchaseInfo(id, request, authentication.getName());
 
         return ResponseEntity.ok(postId);
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -1,9 +1,10 @@
 package com.devcourse.eggmarket.domain.post.converter;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
-import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePost;
+import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostStatus;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.springframework.stereotype.Component;
 
@@ -25,5 +26,13 @@ public class PostConverter {
         post.updateContent(request.content());
         post.updatePrice(request.price());
         post.updateCategory(Category.valueOf(request.category()));
+    }
+
+    public void updateToPurchase(UpdatePurchaseInfo request, Post post,
+        User buyer) {
+        post.updatePurchaseInfo(
+            PostStatus.valueOf(request.postStatus()),
+            buyer
+        );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -14,7 +14,7 @@ public interface PostService {
 
     Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser);
 
-    Long updatePurchaseInfo(PostRequest.UpdatePurchaseInfo request);
+    Long updatePurchaseInfo(Long id, PostRequest.UpdatePurchaseInfo request, String loginUser);
 
     void deleteById(Long id, String loginUser);
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -5,6 +5,7 @@ import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage
 
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
@@ -66,9 +67,13 @@ public class PostServiceImpl implements PostService {
 
     @Transactional
     @Override
-    public Long updatePurchaseInfo(PostRequest.UpdatePurchaseInfo request) {
-        return null;
+    public Long updatePurchaseInfo(Long id, UpdatePurchaseInfo request, String loginUser) {
+        Post post = checkPostWriter(id, loginUser);
+        User buyer = userService.getUser(request.buyerNickName());
+        postConverter.updateToPurchase(request, post, buyer);
+        return post.getId();
     }
+
 
     @Transactional
     @Override

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -158,6 +158,32 @@ class PostServiceImplTest {
     void deleteNotMatchedTest() {
 //        Long request = 1L;
 //        Long userId = 2L;
+    }
+
+    @Test
+    @DisplayName("판매글 판매상태 업데이트 테스트")
+    void updatePurchaseInfoTest() {
+
+    }
+
+    @Test
+    @DisplayName("판매글 상태 업데이트시 전달받은 판매글 ID가 존재하지 않을 경우 예외 발생")
+    void updatePurchaseInfoInvalidIdTest() {
+        PostRequest.UpdatePurchaseInfo request = PostStub.updatePurchaseInfo();
+        Long invalidId = -1L;
+        String loginUser = "test";
+
+        doThrow(new NotExistPostException(NOT_EXIST_POST, invalidId))
+            .when(postRepository)
+            .findById(invalidId);
+
+        assertThatExceptionOfType(NotExistPostException.class)
+            .isThrownBy(() -> postService.updatePurchaseInfo(invalidId, request, loginUser));
+    }
+
+    @Test
+    @DisplayName("판매글 상태 업데이트시 판매글의 판매자 ID와 로그인 사용자의 ID가 다른 경우 예외 발생")
+    void updatePurchaseInfoNotMatchedSellerTest() {
 
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -59,6 +59,11 @@ public class PostStub {
             .build();
     }
 
-
+    public static PostRequest.UpdatePurchaseInfo updatePurchaseInfo() {
+        return new PostRequest.UpdatePurchaseInfo(
+            "COMPLETED",
+            "test"
+        );
+    }
 }
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글의 정보를 변경할때는 `/posts/{id}/post` 판매글의 상태를 변경할 때는 `/posts/{id}/purchase` 로 변경하도록 수정
- 판매자와 로그인 유저가 다를 경우 예외 발생
- 판매글 상태는 구매자와 판매상태만 입력받아 수정하도록 구현

## 작업으로 인해 해결된 이슈 번호
- [EM-61](https://hkasdasdq.atlassian.net/browse/EM-61)

## 문제사항
- id 값 mocking 문제로 인한 테스트 코드 작성 보류