### PR TITLE
✨ feat : 판매글 관심여부 변경 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -1,6 +1,8 @@
 package com.devcourse.eggmarket.domain.post.api;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +21,12 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 public class PostController {
 
     private final PostService postService;
+    private final PostAttentionService postAttentionService;
 
-    public PostController(PostService postService) {
+    public PostController(PostService postService,
+        PostAttentionService postAttentionService) {
         this.postService = postService;
+        this.postAttentionService = postAttentionService;
     }
 
     @PostMapping
@@ -59,5 +64,13 @@ public class PostController {
     ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication) {
         postService.deleteById(id, authentication.getName());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/attention")
+    ResponseEntity<PostResponse.PostLikeCount> attention(@PathVariable("id") Long postId,
+        Authentication authentication) {
+        return ResponseEntity.ok(
+            postAttentionService.toggleAttention(authentication.getName(), postId)
+        );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -1,7 +1,7 @@
 package com.devcourse.eggmarket.domain.post.api;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
 import java.net.URI;
@@ -67,7 +67,7 @@ public class PostController {
     }
 
     @PostMapping("/{id}/attention")
-    ResponseEntity<PostResponse.PostLikeCount> attention(@PathVariable("id") Long postId,
+    ResponseEntity<PostAttentionCount> attention(@PathVariable("id") Long postId,
         Authentication authentication) {
         return ResponseEntity.ok(
             postAttentionService.toggleAttention(authentication.getName(), postId)

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -2,10 +2,13 @@ package com.devcourse.eggmarket.domain.post.converter;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostStatus;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
+import java.util.Collections;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,6 +36,30 @@ public class PostConverter {
         post.updatePurchaseInfo(
             PostStatus.valueOf(request.postStatus()),
             buyer
+        );
+    }
+
+    public PostResponse singlePost(Post post, boolean likeOfMe) {
+        User seller = post.getSeller();
+
+        return new PostResponse(
+            post.getId(),
+            new UserResponse(
+                seller.getId(),
+                seller.getNickName(),
+                seller.getMannerTemperature(),
+                seller.getRole().toString(),
+                seller.getImagePath()),
+            post.getPrice(),
+            post.getTitle(),
+            post.getContent(),
+            post.getPostStatus().name(),
+            post.getCategory().name(),
+            post.getCreatedAt(),
+            post.getAttentionCount(),
+            0, // TODO : Comment 개수
+            likeOfMe,
+            Collections.emptyList()
         );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -39,10 +39,10 @@ public class PostConverter {
         );
     }
 
-    public PostResponse singlePost(Post post, boolean likeOfMe) {
+    public PostResponse.SinglePost singlePost(Post post, boolean likeOfMe) {
         User seller = post.getSeller();
 
-        return new PostResponse(
+        return new PostResponse.SinglePost(
             post.getId(),
             new UserResponse(
                 seller.getId(),

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -26,7 +26,7 @@ public class PostResponse {
 
     }
 
-    public record PostLikeCount(int likeCount) {
+    public record PostAttentionCount(int likeCount) {
 
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -3,7 +3,10 @@ package com.devcourse.eggmarket.domain.post.dto;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostResponse {
 
     public record SinglePost(
@@ -20,6 +23,10 @@ public class PostResponse {
         boolean likeOfMe,
         List<String> imagePaths
     ) {
+
+    }
+
+    public record PostLikeCount(int likeCount) {
 
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -4,19 +4,22 @@ import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record PostResponse(
-    Long id,
-    UserResponse seller,
-    int price,
-    String title,
-    String content,
-    String postStatus,
-    String category,
-    LocalDateTime createAt,
-    int attentionCount,
-    int commentCount,
-    boolean likeOfMe,
-    List<String> imagePaths
-) {
+public class PostResponse {
 
+    public record SinglePost(
+        Long id,
+        UserResponse seller,
+        int price,
+        String title,
+        String content,
+        String postStatus,
+        String category,
+        LocalDateTime createAt,
+        int attentionCount,
+        int commentCount,
+        boolean likeOfMe,
+        List<String> imagePaths
+    ) {
+
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -1,18 +1,22 @@
 package com.devcourse.eggmarket.domain.post.dto;
 
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record PostResponse(
     Long id,
-    Long sellerId,
-    Long buyerId,
+    UserResponse seller,
     int price,
     String title,
     String content,
     String postStatus,
     String category,
     LocalDateTime createAt,
-    LocalDateTime updatedAt
+    int attentionCount,
+    int commentCount,
+    boolean likeOfMe,
+    List<String> imagePaths
 ) {
 
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
@@ -19,6 +19,7 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -55,12 +56,17 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "buyer_id")
     private User buyer;
 
-    private Post(String title,
+    @Formula("(select count(*) from post_attention pa where pa.post_id = id)")
+    private int attentionCount;
+
+    private Post(Long id,
+        String title,
         String content,
         Category category,
         int price,
         PostStatus postStatus,
         User seller) {
+        this.id = id;
         this.title = title;
         this.content = content;
         this.category = category;
@@ -70,8 +76,8 @@ public class Post extends BaseEntity {
     }
 
     @Builder
-    public Post(String title, String content, Category category, int price, User seller) {
-        this(title, content, category, price, PostStatus.SALE, seller);
+    public Post(Long id, String title, String content, Category category, int price, User seller) {
+        this(id, title, content, category, price, PostStatus.SALE, seller);
     }
 
     public Long getId() {
@@ -104,6 +110,10 @@ public class Post extends BaseEntity {
 
     public User getBuyer() {
         return buyer;
+    }
+
+    public int getAttentionCount() {
+        return attentionCount;
     }
 
     public void updatePrice(int price) {

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
@@ -11,6 +11,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -52,7 +53,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "seller_id")
     private User seller;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "buyer_id")
     private User buyer;
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
@@ -32,15 +32,15 @@ public class PostAttention extends BaseEntity {
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
+    public PostAttention(Post post, User user) {
+        this(null, post, user);
+    }
+
+    @Builder
     public PostAttention(Long id, Post post, User user) {
         this.id = id;
         this.post = post;
         this.user = user;
-    }
-
-    @Builder
-    public PostAttention(Post post, User user) {
-        this(null, post, user);
     }
 
     public Post getPost() {

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
@@ -1,0 +1,53 @@
+package com.devcourse.eggmarket.domain.post.model;
+
+import com.devcourse.eggmarket.domain.model.BaseEntity;
+import com.devcourse.eggmarket.domain.user.model.User;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostAttention extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    private Post post;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    public PostAttention(Long id, Post post, User user) {
+        this.id = id;
+        this.post = post;
+        this.user = user;
+    }
+
+    @Builder
+    public PostAttention(Post post, User user) {
+        this(null, post, user);
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepository.java
@@ -1,0 +1,8 @@
+package com.devcourse.eggmarket.domain.post.repository;
+
+import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostAttentionRepository extends JpaRepository<PostAttention, Long> {
+
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepository.java
@@ -1,8 +1,14 @@
 package com.devcourse.eggmarket.domain.post.repository;
 
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostAttentionRepository extends JpaRepository<PostAttention, Long> {
+    @Query("select pa from PostAttention pa where pa.post.id = :postId and pa.user.id = :userId")
+    Optional<PostAttention> findByPostIdAndUserId(Long postId, Long userId);
 
+    @Query("select count(pa) from PostAttention pa where pa.post.id = :postId")
+    int countPostLikeByPost(Long postId);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
@@ -1,0 +1,50 @@
+package com.devcourse.eggmarket.domain.post.service;
+
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostLikeCount;
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
+import com.devcourse.eggmarket.domain.post.repository.PostRepository;
+import com.devcourse.eggmarket.domain.user.model.User;
+import com.devcourse.eggmarket.domain.user.service.UserService;
+import javax.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultPostAttentionService implements PostAttentionService {
+
+    private final PostAttentionRepository postAttentionRepository;
+    private final PostRepository postRepository;
+    private final UserService userService;
+
+    public DefaultPostAttentionService(
+        PostAttentionRepository postAttentionRepository,
+        PostRepository postRepository,
+        UserService userService) {
+        this.postAttentionRepository = postAttentionRepository;
+        this.postRepository = postRepository;
+        this.userService = userService;
+    }
+
+    private User getUser(String nickName) {
+        return userService.getUser(nickName);
+    }
+
+    @Override
+    public PostLikeCount toggleAttention(String userName, Long postId) {
+        User loginUser = getUser(userName);
+
+        Post post = postRepository.findById(postId)
+            .orElseThrow(EntityNotFoundException::new);
+
+        postAttentionRepository.findByPostIdAndUserId(postId, loginUser.getId())
+            .ifPresentOrElse(postAttentionRepository::delete, () ->
+                postAttentionRepository.save(new PostAttention(post, loginUser))
+            );
+
+        return new PostResponse.PostLikeCount(
+            postAttentionRepository.countPostLikeByPost(postId)
+        );
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
@@ -1,7 +1,6 @@
 package com.devcourse.eggmarket.domain.post.service;
 
-import com.devcourse.eggmarket.domain.post.dto.PostResponse;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostLikeCount;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
@@ -32,7 +31,7 @@ public class DefaultPostAttentionService implements PostAttentionService {
     }
 
     @Override
-    public PostLikeCount toggleAttention(String userName, Long postId) {
+    public PostAttentionCount toggleAttention(String userName, Long postId) {
         User loginUser = getUser(userName);
 
         Post post = postRepository.findById(postId)
@@ -43,7 +42,7 @@ public class DefaultPostAttentionService implements PostAttentionService {
                 postAttentionRepository.save(new PostAttention(post, loginUser))
             );
 
-        return new PostResponse.PostLikeCount(
+        return new PostAttentionCount(
             postAttentionRepository.countPostLikeByPost(postId)
         );
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
@@ -1,0 +1,8 @@
+package com.devcourse.eggmarket.domain.post.service;
+
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+
+public interface PostAttentionService {
+
+    PostResponse.PostLikeCount toggleAttention(String userName, Long postId);
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
@@ -1,8 +1,8 @@
 package com.devcourse.eggmarket.domain.post.service;
 
-import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 
 public interface PostAttentionService {
 
-    PostResponse.PostLikeCount toggleAttention(String userName, Long postId);
+    PostAttentionCount toggleAttention(String userName, Long postId);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -3,10 +3,8 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
-import com.devcourse.eggmarket.domain.user.model.User;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.Authentication;
 
 public interface PostService {
 
@@ -18,9 +16,9 @@ public interface PostService {
 
     void deleteById(Long id, String loginUser);
 
-    PostResponse getById(Long id);
+    PostResponse.SinglePost getById(Long id);
 
-    List<PostResponse> getAll(Pageable pageable);
+    List<PostResponse.SinglePost> getAll(Pageable pageable);
 
-    List<PostResponse> getAllByCategory(Pageable pageable, String category);
+    List<PostResponse.SinglePost> getAllByCategory(Pageable pageable, String category);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -83,18 +83,18 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostResponse getById(Long id) {
+    public PostResponse.SinglePost getById(Long id) {
         return null;
     }
 
     @Override
-    public List<PostResponse> getAll(Pageable pageable) {
+    public List<PostResponse.SinglePost> getAll(Pageable pageable) {
         return null;
     }
 
 
     @Override
-    public List<PostResponse> getAllByCategory(Pageable pageable, String category) {
+    public List<PostResponse.SinglePost> getAllByCategory(Pageable pageable, String category) {
         return null;
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
@@ -67,7 +67,7 @@ class PostConverterTest {
 
         boolean isLoginUserLikePost = false;
 
-        PostResponse expected = new PostResponse(
+        PostResponse.SinglePost expected = new PostResponse.SinglePost(
             post.getId(),
             new UserResponse(writer.getId(), writer.getNickName(), writer.getMannerTemperature(),
                 writer.getRole().toString(), writer.getImagePath()),
@@ -83,7 +83,7 @@ class PostConverterTest {
             Collections.emptyList()
         );
 
-        PostResponse postResponse = postConverter.singlePost(post, isLoginUserLikePost);
+        PostResponse.SinglePost postResponse = postConverter.singlePost(post, isLoginUserLikePost);
 
         assertThat(postResponse).usingRecursiveComparison().isEqualTo(expected);
 

--- a/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
@@ -1,12 +1,15 @@
 package com.devcourse.eggmarket.domain.post.converter;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
+import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +43,49 @@ class PostConverterTest {
         Post got = postConverter.saveToPost(request, seller);
 
         assertThat(got).usingRecursiveComparison().isEqualTo(want);
+    }
+
+    @Test
+    @DisplayName("Post , 현재 로그인 한 사용자의 관심목록 추가 여부 정보를 사용하여 PostResponse 를 생성한다")
+    public void makeSinglePostResponseTest() {
+        User writer = User.builder()
+//            .id(1L)
+            .phoneNumber("123456789")
+            .nickName("user01")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        Post post = Post.builder()
+            .title("title01")
+            .content("content01")
+            .seller(writer)
+            .price(1000)
+            .category(Category.BEAUTY)
+            .id(1L)
+            .build();
+
+        boolean isLoginUserLikePost = false;
+
+        PostResponse expected = new PostResponse(
+            post.getId(),
+            new UserResponse(writer.getId(), writer.getNickName(), writer.getMannerTemperature(),
+                writer.getRole().toString(), writer.getImagePath()),
+            post.getPrice(),
+            post.getTitle(),
+            post.getContent(),
+            post.getPostStatus().toString(),
+            post.getCategory().toString(),
+            post.getCreatedAt(),
+            post.getAttentionCount(),
+            0, // TODO : Comment 개수
+            isLoginUserLikePost,
+            Collections.emptyList()
+        );
+
+        PostResponse postResponse = postConverter.singlePost(post, isLoginUserLikePost);
+
+        assertThat(postResponse).usingRecursiveComparison().isEqualTo(expected);
+
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostAttentionRepositoryTest.java
@@ -14,51 +14,40 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class PostRepositoryTest {
+class PostAttentionRepositoryTest {
 
     @Autowired
-    private UserRepository userRepository;
+    public PostAttentionRepository postAttentionRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    public UserRepository userRepository;
 
     @Autowired
-    private PostAttentionRepository postAttentionRepository;
+    public PostRepository postRepository;
 
-    private User writer;
-    private User notWriter;
+    private User writerLikedOwnPost;
     private Post post;
 
     @BeforeEach
     void setUp() {
-        writer = User.builder()
+        writerLikedOwnPost = User.builder()
             .phoneNumber("123456789")
             .nickName("user01")
             .password("User01234*")
             .role("USER")
             .build();
 
-        notWriter = User.builder()
-            .phoneNumber("123456780")
-            .nickName("user02")
-            .password("User01234*")
-            .role("USER")
-            .build();
-
         post = Post.builder()
-            .price(1000)
-            .content("content01")
-            .category(Category.BEAUTY)
             .title("title01")
-            .seller(writer)
+            .content("content01")
+            .seller(writerLikedOwnPost)
+            .price(1000)
+            .category(Category.BEAUTY)
             .build();
 
-        PostAttention postAttention = new PostAttention(post, notWriter);
-
-        userRepository.save(writer);
-        userRepository.save(notWriter);
+        userRepository.save(writerLikedOwnPost);
         postRepository.save(post);
-        postAttentionRepository.save(postAttention);
+        postAttentionRepository.save(new PostAttention(post, writerLikedOwnPost));
     }
 
     @AfterEach
@@ -69,11 +58,12 @@ public class PostRepositoryTest {
     }
 
     @Test
-    @DisplayName("조회해 온 포스트 엔티티에 대한 관심개수를 알 수 있다")
-    public void attentionCount() {
-        Post foundPost = postRepository.findById(this.post.getId()).get();
+    @DisplayName("Post 와 로그인 사용자 정보를 통해 해당 사용자가 해당 게시글에 관심목록으로 추가했는지 여부를 알 수 있다")
+    public void findPostAttentionByPostAndUser() {
+        boolean present = postAttentionRepository.findByPostIdAndUserId(post.getId(),
+                writerLikedOwnPost.getId())
+            .isPresent();
 
-        Assertions.assertThat(foundPost.getAttentionCount())
-            .isEqualTo(1);
+        Assertions.assertThat(present).isTrue();
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.devcourse.eggmarket.domain.post.repository;
+
+import com.devcourse.eggmarket.domain.post.model.Category;
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.user.model.User;
+import com.devcourse.eggmarket.domain.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PostRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostAttentionRepository postAttentionRepository;
+
+    private User writer;
+    private User notWriter;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        writer = User.builder()
+            .phoneNumber("123456789")
+            .nickName("user01")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        notWriter = User.builder()
+            .phoneNumber("123456780")
+            .nickName("user02")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        post = Post.builder()
+            .price(1000)
+            .content("content01")
+            .category(Category.BEAUTY)
+            .title("title01")
+            .seller(writer)
+            .build();
+
+        PostAttention postAttention = new PostAttention(post, notWriter);
+
+        userRepository.save(writer);
+        userRepository.save(notWriter);
+        postRepository.save(post);
+        postAttentionRepository.save(postAttention);
+    }
+
+    @Test
+    @DisplayName("현재 포스트가 몇 개의 관심목록에 추가되어있는지 알 수 있다")
+    public void attentionCount() {
+        Post foundPost = postRepository.findById(this.post.getId()).get();
+
+        Assertions.assertThat(foundPost.getAttentionCount())
+            .isEqualTo(1);
+    }
+}

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.devcourse.eggmarket.domain.post.service;
+
+import com.devcourse.eggmarket.domain.post.model.Category;
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
+import com.devcourse.eggmarket.domain.post.repository.PostRepository;
+import com.devcourse.eggmarket.domain.user.model.User;
+import com.devcourse.eggmarket.domain.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PostServiceIntegrationTest {
+    @Autowired
+    public PostAttentionRepository postAttentionRepository;
+
+    @Autowired
+    public UserRepository userRepository;
+
+    @Autowired
+    public PostRepository postRepository;
+
+    @Autowired
+    public PostAttentionService postAttentionService;
+
+    private User writerLikedOwnPost;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        writerLikedOwnPost = User.builder()
+            .phoneNumber("123456789")
+            .nickName("user01")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        post = Post.builder()
+            .title("title01")
+            .content("content01")
+            .seller(writerLikedOwnPost)
+            .price(1000)
+            .category(Category.BEAUTY)
+            .build();
+
+        userRepository.save(writerLikedOwnPost);
+        postRepository.save(post);
+        postAttentionRepository.save(new PostAttention(post, writerLikedOwnPost));
+    }
+
+    @AfterEach
+    void tearDown() {
+        postAttentionRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 관심목록 추가 버튼을 누르면 관심상태가 반대 상태로 변경된다")
+    public void toggleAttention() {
+        postAttentionService.toggleAttention(writerLikedOwnPost.getNickName(), post.getId());
+
+        boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(post.getId(),
+                writerLikedOwnPost.getId())
+            .isPresent();
+
+        Assertions.assertThat(afterLikeOfMe).isFalse();
+    }
+}


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 💥  Post 생성자에 Long id 를 인자로 받도록 변경하였습니다 💥 
- 💥  PostResponse 를 아우터 클래스로 변경
  - SinglePost
  - PostLikeCount 등 여러개의 응답 객체 필요성으로 인해 아우터 클래스로변경함
- 포스트 단일 응답 객체 의 필드 변경
  - sellerId, buyerId 삭제
    - 추후 : buyer 포함(?)
  - UserResponse 추가
  - likeCount 추가
  - commentCount 추가 (Converter 에서 일단 무조건 0 이 들어오게 세팅)
  - imgPath List 추가 (일단 EmptyCollection 들어오게 세팅)
- 관심 버튼을 누르면 해당 게시글에 대한, 로그인한 사용자의 관심 여부가 반대로 변경되도록 하는 기능 추가
  - posts/{id}/attention + POST METHOD 를 통해, 현재 로그인 사용자는 해당 게시글에 대한 "관심" 여부를 변경할 수 있다 
  - 관심 버튼을 누르면, 결과로 "관심 개수" 가 리턴된다

## 작성하며 변경되야 할 것이라고 생각된 부분
-  seller 는 POST와의 연관관계를 EAGER 로 하기로 했었는데, buyer 는 LAZY 로 하기로 했던 것 같습니다 . 그런데 현재 buyer 와의 관계도 EAGER 로 되어있는 것을 확인하였습니다. 


## 다음 PR 예정 작업
- PostImage "엔티티" 추가  예정입니다.
- --- 이에 따라 Post write 관련 기존 로직에 변경될 예정입니다! Post 도 당연히 변경될 예정입니다(용철님 작성부분)💥
- --- 기존의 Image 인터페이스를 -> ImageFile 이라는 네이밍으로 변경할 예정입니다! 이로 인해 PostImageFile, ProfileImageFile 이라는 네이밍으로 변경할 예정입니다!(지영님 작성부분)💥

## 작업으로 인해 해결된 이슈 번호
- EM-32 