### PR TITLE
✨ feat : 로그인 사용자의 관심목록 불러오기 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -2,12 +2,14 @@ package com.devcourse.eggmarket.domain.post.api;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,6 +73,13 @@ public class PostController {
         Authentication authentication) {
         return ResponseEntity.ok(
             postAttentionService.toggleAttention(authentication.getName(), postId)
+        );
+    }
+
+    @GetMapping("/attention")
+    ResponseEntity<Posts> allAttention(Authentication authentication) {
+        return ResponseEntity.ok(
+            postAttentionService.getAllLikedBy(authentication.getName())
         );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -66,16 +66,8 @@ public class PostConverter {
     }
 
     public PostResponse.PostsElement postsElement(Post post, String imgPath) {
-        User seller = post.getSeller();
-
         return new PostsElement(
             post.getId(),
-            new UserResponse(
-                seller.getId(),
-                seller.getNickName(),
-                seller.getMannerTemperature(),
-                seller.getRole().toString(),
-                seller.getImagePath()),
             post.getPrice(),
             post.getTitle(),
             post.getPostStatus().toString(),

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -44,6 +44,7 @@ public class PostConverter {
 
         return new PostResponse.SinglePost(
             post.getId(),
+            // TODO : UserConverter 사용 고려 (주의: 순환참조되지 않도록 -> 즉 PostConverter 에서 UserConverter 를 사용한다면 UserConverter 에서는 PostConverter를 사용하면 안됩니다)
             new UserResponse(
                 seller.getId(),
                 seller.getNickName(),

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -3,12 +3,13 @@ package com.devcourse.eggmarket.domain.post.converter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostStatus;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
-import java.util.Collections;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,12 +40,12 @@ public class PostConverter {
         );
     }
 
-    public PostResponse.SinglePost singlePost(Post post, boolean likeOfMe) {
+    public PostResponse.SinglePost singlePost(Post post, boolean likeOfMe, List<String> imgPaths) {
         User seller = post.getSeller();
 
         return new PostResponse.SinglePost(
             post.getId(),
-            // TODO : UserConverter 사용 고려 (주의: 순환참조되지 않도록 -> 즉 PostConverter 에서 UserConverter 를 사용한다면 UserConverter 에서는 PostConverter를 사용하면 안됩니다)
+            // TODO : UserConverter 사용 고려 (주의: 순환참조되지 않도록 -> 즉 PostConverter 에서 UserConverter 를 사용한다면 UserConverter 에서는 PostConverter 를 사용하면 안됩니다)
             new UserResponse(
                 seller.getId(),
                 seller.getNickName(),
@@ -58,9 +59,30 @@ public class PostConverter {
             post.getCategory().name(),
             post.getCreatedAt(),
             post.getAttentionCount(),
-            0, // TODO : Comment 개수
+            0, // TODO : Comment 개수 를 post 로부터 받아온다
             likeOfMe,
-            Collections.emptyList()
+            imgPaths
+        );
+    }
+
+    public PostResponse.PostsElement postsElement(Post post, String imgPath) {
+        User seller = post.getSeller();
+
+        return new PostsElement(
+            post.getId(),
+            new UserResponse(
+                seller.getId(),
+                seller.getNickName(),
+                seller.getMannerTemperature(),
+                seller.getRole().toString(),
+                seller.getImagePath()),
+            post.getPrice(),
+            post.getTitle(),
+            post.getPostStatus().toString(),
+            post.getCreatedAt(),
+            post.getAttentionCount(),
+            0, // TODO : 커멘트 개수 post 에서 가져오기
+            imgPath
         );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -29,4 +29,22 @@ public class PostResponse {
     public record PostAttentionCount(int likeCount) {
 
     }
+
+    public record PostsElement(
+        Long id,
+        UserResponse seller,
+        int price,
+        String title,
+        String postStatus,
+        LocalDateTime createdAt,
+        int attentionCount,
+        int commentCount,
+        String imagePath
+    ) {
+
+    }
+
+    public record Posts(List<PostsElement> posts) {
+
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -32,7 +32,6 @@ public class PostResponse {
 
     public record PostsElement(
         Long id,
-        UserResponse seller,
         int price,
         String title,
         String postStatus,

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
@@ -1,8 +1,16 @@
 package com.devcourse.eggmarket.domain.post.repository;
 
 import com.devcourse.eggmarket.domain.post.model.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    @Query("select p "
+        + "from Post p inner join PostAttention pa on pa.post.id = p.id "
+        + "inner join fetch p.seller "
+        + "WHERE pa.user.id = :userId")
+    List<Post> findAllLikedBy(@Param("userId") Long userId);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
@@ -1,12 +1,15 @@
 package com.devcourse.eggmarket.domain.post.service;
 
+import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
+import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -15,19 +18,18 @@ public class DefaultPostAttentionService implements PostAttentionService {
 
     private final PostAttentionRepository postAttentionRepository;
     private final PostRepository postRepository;
+    private final PostConverter postConverter;
     private final UserService userService;
 
     public DefaultPostAttentionService(
         PostAttentionRepository postAttentionRepository,
         PostRepository postRepository,
+        PostConverter postConverter,
         UserService userService) {
         this.postAttentionRepository = postAttentionRepository;
         this.postRepository = postRepository;
+        this.postConverter = postConverter;
         this.userService = userService;
-    }
-
-    private User getUser(String nickName) {
-        return userService.getUser(nickName);
     }
 
     @Override
@@ -38,12 +40,26 @@ public class DefaultPostAttentionService implements PostAttentionService {
             .orElseThrow(EntityNotFoundException::new);
 
         postAttentionRepository.findByPostIdAndUserId(postId, loginUser.getId())
-            .ifPresentOrElse(postAttentionRepository::delete, () ->
-                postAttentionRepository.save(new PostAttention(post, loginUser))
+            .ifPresentOrElse(
+                postAttentionRepository::delete, () ->
+                    postAttentionRepository.save(new PostAttention(post, loginUser))
             );
 
         return new PostAttentionCount(
             postAttentionRepository.countPostLikeByPost(postId)
         );
+    }
+
+    @Override
+    public Posts getAllLikedBy(String userName) {
+        return new Posts(
+            postRepository.findAllLikedBy(
+                    getUser(userName).getId()).stream()
+                .map(post -> postConverter.postsElement(post, null)) // TODO : 한 개의 이미지 경로 가져오기
+                .collect(Collectors.toList()));
+    }
+
+    private User getUser(String nickName) {
+        return userService.getUser(nickName);
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
@@ -1,8 +1,11 @@
 package com.devcourse.eggmarket.domain.post.service;
 
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 
 public interface PostAttentionService {
 
     PostAttentionCount toggleAttention(String userName, Long postId);
+
+    Posts getAllLikedBy(String userName);
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
@@ -83,7 +83,8 @@ class PostConverterTest {
             Collections.emptyList()
         );
 
-        PostResponse.SinglePost postResponse = postConverter.singlePost(post, isLoginUserLikePost);
+        PostResponse.SinglePost postResponse = postConverter.singlePost(post, isLoginUserLikePost,
+            Collections.emptyList());
 
         assertThat(postResponse).usingRecursiveComparison().isEqualTo(expected);
 

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
@@ -27,7 +27,8 @@ public class PostRepositoryTest {
 
     private User writer;
     private User notWriter;
-    private Post post;
+    private Post likedPost1;
+    private Post likedPost2;
 
     @BeforeEach
     void setUp() {
@@ -45,7 +46,7 @@ public class PostRepositoryTest {
             .role("USER")
             .build();
 
-        post = Post.builder()
+        likedPost1 = Post.builder()
             .price(1000)
             .content("content01")
             .category(Category.BEAUTY)
@@ -53,12 +54,21 @@ public class PostRepositoryTest {
             .seller(writer)
             .build();
 
-        PostAttention postAttention = new PostAttention(post, notWriter);
+        likedPost2 = Post.builder()
+            .price(1400)
+            .title("title11")
+            .content("content12")
+            .category(Category.BEAUTY)
+            .seller(writer)
+            .build();
 
         userRepository.save(writer);
         userRepository.save(notWriter);
-        postRepository.save(post);
-        postAttentionRepository.save(postAttention);
+        postRepository.save(likedPost1);
+        postRepository.save(likedPost2);
+
+        postAttentionRepository.save(new PostAttention(likedPost1, notWriter));
+        postAttentionRepository.save(new PostAttention(likedPost2, notWriter));
     }
 
     @AfterEach
@@ -71,9 +81,18 @@ public class PostRepositoryTest {
     @Test
     @DisplayName("조회해 온 포스트 엔티티에 대한 관심개수를 알 수 있다")
     public void attentionCount() {
-        Post foundPost = postRepository.findById(this.post.getId()).get();
+        Post foundPost = postRepository.findById(this.likedPost1.getId()).get();
 
         Assertions.assertThat(foundPost.getAttentionCount())
             .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("특정한 사용자가 관심목록에 추가 한 모든 게시글을 찾아올 수 있다")
+    public void test() {
+        int likedPostsCount = postRepository.findAllLikedBy(notWriter.getId()).size();
+
+        Assertions.assertThat(likedPostsCount)
+            .isEqualTo(2);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.devcourse.eggmarket.domain.post.service;
 
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 public class PostServiceIntegrationTest {
+
     @Autowired
     public PostAttentionRepository postAttentionRepository;
 
@@ -30,7 +32,9 @@ public class PostServiceIntegrationTest {
     public PostAttentionService postAttentionService;
 
     private User writerLikedOwnPost;
-    private Post post;
+    private User notYetLikedUser;
+    private Post likedPost1;
+    private Post likedPost2;
 
     @BeforeEach
     void setUp() {
@@ -41,7 +45,14 @@ public class PostServiceIntegrationTest {
             .role("USER")
             .build();
 
-        post = Post.builder()
+        notYetLikedUser = User.builder()
+            .phoneNumber("123456780")
+            .nickName("user02")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        likedPost1 = Post.builder()
             .title("title01")
             .content("content01")
             .seller(writerLikedOwnPost)
@@ -49,9 +60,20 @@ public class PostServiceIntegrationTest {
             .category(Category.BEAUTY)
             .build();
 
+        likedPost2 = Post.builder()
+            .price(1400)
+            .title("title11")
+            .content("content12")
+            .category(Category.BEAUTY)
+            .seller(writerLikedOwnPost)
+            .build();
+
         userRepository.save(writerLikedOwnPost);
-        postRepository.save(post);
-        postAttentionRepository.save(new PostAttention(post, writerLikedOwnPost));
+        userRepository.save(notYetLikedUser);
+        postRepository.save(likedPost1);
+        postRepository.save(likedPost2);
+        postAttentionRepository.save(new PostAttention(likedPost1, writerLikedOwnPost));
+        postAttentionRepository.save(new PostAttention(likedPost2, writerLikedOwnPost));
     }
 
     @AfterEach
@@ -62,14 +84,35 @@ public class PostServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("로그인 사용자가 관심목록 추가 버튼을 누르면 관심상태가 반대 상태로 변경된다")
-    public void toggleAttention() {
-        postAttentionService.toggleAttention(writerLikedOwnPost.getNickName(), post.getId());
+    @DisplayName("관심목록에 추가했던 로그인 사용자가 관심목록 추가 버튼을 누르면 관심목록에서 제거한다")
+    public void toggleAttentionToDisable() {
+        postAttentionService.toggleAttention(writerLikedOwnPost.getNickName(), likedPost1.getId());
 
-        boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(post.getId(),
+        boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(likedPost1.getId(),
                 writerLikedOwnPost.getId())
             .isPresent();
 
         Assertions.assertThat(afterLikeOfMe).isFalse();
+    }
+
+    @Test
+    @DisplayName("관심목록에 추가한 적 없던 로그인 사용자가 관심목록 추가 버튼을 누르면 관심목록에 추가한다")
+    public void toggleAttentionToEnable() {
+        postAttentionService.toggleAttention(notYetLikedUser.getNickName(), likedPost1.getId());
+
+        boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(likedPost1.getId(),
+                notYetLikedUser.getId())
+            .isPresent();
+
+        Assertions.assertThat(afterLikeOfMe).isTrue();
+    }
+
+    @Test
+    @DisplayName("로그인 사용자는 자신의 관심목록을 확인한다")
+    public void getAllLikedPosts() {
+        Posts allLikedPosts = postAttentionService.getAllLikedBy(
+            writerLikedOwnPost.getNickName());
+
+        Assertions.assertThat(allLikedPosts.posts().size()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- PostAttentionRepository 에, 특정 사용자가 관심목록으로 추가한 판매글들을 불러오는 쿼리 추가 ( 페이징은 구현 ❌ )
- 판매글 응답 DTO 추가 와 그에 따른 컨버터 메소드 추가 및 테스트 추가
  - 판매글 "목록" 을 불러올 때 판매글에 포함되어야 할 데이터와 "판매글만 단일조회할 때 데이터" 는 다르다는 판단하에 별도의 DTO 를작성
    - PostsElement
  - 판매글 목록에 대해 Posts 라는 응답으로 List 형태로 반환 하도록 하였음
    - Posts
      - 🔆 후에 Paging 과 관련하여 생각하시는게 있다면, 이 부분이 변경될 수 있다고 생각합니다. 저는 아직 Paging 관련 작성을 고려하지 않아 이렇게 작성하였습니다
- 관심목록에 "추가" 하는 테스트와 "삭제" 하는 테스트를 별도로 작성하여 추가함

## 작업으로 인해 해결된 이슈 번호
- EM-62