### PR TITLE
✨ feat : 판매글 단일 조회 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -1,6 +1,7 @@
 package com.devcourse.eggmarket.domain.post.api;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
@@ -81,5 +82,11 @@ public class PostController {
         return ResponseEntity.ok(
             postAttentionService.getAllLikedBy(authentication.getName())
         );
+    }
+
+    @GetMapping("/{id}")
+    ResponseEntity<PostResponse.SinglePost> getPost(@PathVariable Long id, Authentication authentication) {
+        PostResponse.SinglePost response = postService.getById(id, authentication.getName());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -76,5 +76,6 @@ public class PostConverter {
             0, // TODO : 커멘트 개수 post 에서 가져오기
             imgPath
         );
+
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 
 public interface PostService {
 
@@ -16,7 +17,7 @@ public interface PostService {
 
     void deleteById(Long id, String loginUser);
 
-    PostResponse.SinglePost getById(Long id);
+    PostResponse.SinglePost getById(Long id, String loginUser);
 
     List<PostResponse.SinglePost> getAll(Pageable pageable);
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -10,11 +10,14 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,12 +31,16 @@ public class PostServiceImpl implements PostService {
 
     private final PostConverter postConverter;
 
+    private final PostAttentionRepository postAttentionRepository;
+
     public PostServiceImpl(PostRepository postRepository,
         UserService userService,
-        PostConverter postConverter) {
+        PostConverter postConverter,
+        PostAttentionRepository postAttentionRepository) {
         this.postRepository = postRepository;
         this.userService = userService;
         this.postConverter = postConverter;
+        this.postAttentionRepository = postAttentionRepository;
     }
 
     private Post checkPostWriter(Long postId, String loginUser) {
@@ -83,8 +90,13 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostResponse.SinglePost getById(Long id) {
-        return null;
+    public PostResponse.SinglePost getById(Long id, String loginUser) {
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, id));
+        User user = userService.getUser(loginUser);
+        boolean attention = postAttentionRepository.findByPostIdAndUserId(id, user.getId())
+            .isPresent();
+        return postConverter.singlePost(post, attention, null);
     }
 
     @Override

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -2,8 +2,11 @@ package com.devcourse.eggmarket.domain.stub;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePost;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.SinglePost;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
 
 public class PostStub {
@@ -63,6 +66,30 @@ public class PostStub {
         return new PostRequest.UpdatePurchaseInfo(
             "COMPLETED",
             "test"
+        );
+    }
+
+    public static SinglePost singlePostResponse(Post post) {
+        User seller = post.getSeller();
+        return new PostResponse.SinglePost(
+            post.getId(),
+            new UserResponse(
+                seller.getId(),
+                seller.getNickName(),
+                seller.getMannerTemperature(),
+                seller.getRole().name(),
+                seller.getImagePath()
+            ),
+            post.getPrice(),
+            post.getTitle(),
+            post.getContent(),
+            post.getPostStatus().name(),
+            post.getCategory().name(),
+            post.getCreatedAt(),
+            post.getAttentionCount(),
+            0,
+            true,
+            null
         );
     }
 }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 ID를 통해 게시글을 단일 조회하는 기능 구현
- 판매글을 단일조회시 필요한 정보만 담아 변환하는 메서드 추가
- 판매글 단일 조회 테스트 코드 작성

## 작업으로 인해 해결된 이슈 번호
- [EM-43](https://hkasdasdq.atlassian.net/browse/EM-43)