### PR TITLE
✨ feat: 판매글 작성시 이미지 업로드 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageFile.java
@@ -2,7 +2,7 @@ package com.devcourse.eggmarket.domain.model.image;
 
 import org.springframework.web.multipart.MultipartFile;
 
-public interface Image {
+public interface ImageFile {
 
     byte[] getContents();
 

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageUpload.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageUpload.java
@@ -2,7 +2,7 @@ package com.devcourse.eggmarket.domain.model.image;
 
 public interface ImageUpload {
 
-    String upload(Image image);
+    String upload(ImageFile image);
 
     void deleteFile(String imagePath);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/LocalImageUpload.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/LocalImageUpload.java
@@ -21,7 +21,7 @@ public class LocalImageUpload implements ImageUpload {
     }
 
     @Override
-    public String upload(Image image) {
+    public String upload(ImageFile image) {
         String path = imgPath(image);
 
         try {
@@ -32,7 +32,7 @@ public class LocalImageUpload implements ImageUpload {
         return path;
     }
 
-    private String imgPath(Image image) {
+    private String imgPath(ImageFile image) {
         return switch (image.getType()) {
             case POST -> image.pathTobeStored(pathProperties.postImagePath());
             case PROFILE -> image.pathTobeStored(pathProperties.profileImagePath());

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-public class PostImage implements Image {
+public class PostImageFile implements ImageFile {
 
     private static final String DELIMITER = "_";
     private static final String EXTENSION_SEPARATOR = ".";
@@ -17,7 +17,7 @@ public class PostImage implements Image {
     private final int order; // 이미지 순서
     private final long id; // 판매글 id
 
-    private PostImage(ImageType type, byte[] bytes, String extension, int order,
+    private PostImageFile(ImageType type, byte[] bytes, String extension, int order,
         String fileName,
         long id) {
         this.type = type;
@@ -28,18 +28,18 @@ public class PostImage implements Image {
         this.id = id;
     }
 
-    private PostImage(ImageType type, byte[] bytes, int order, String fileName,
+    private PostImageFile(ImageType type, byte[] bytes, int order, String fileName,
         long id) {
         this(type, bytes, FilenameUtils.getExtension(fileName), order, fileName, id);
     }
 
-    public static PostImage toImage(long postId, MultipartFile file, int img_order) {
-        if (Image.isNotImage(file)) {
+    public static PostImageFile toImage(long postId, MultipartFile file, int img_order) {
+        if (ImageFile.isNotImage(file)) {
             throw new InvalidFileException("유효한 이미지 첨부가 아닙니다"); // 참고로 이미지 크기 오류는 따로 존재합니다
         }
 
         try (InputStream inputStream = file.getInputStream()) {
-            return new PostImage(ImageType.POST, inputStream.readAllBytes(), img_order,
+            return new PostImageFile(ImageType.POST, inputStream.readAllBytes(), img_order,
                 file.getOriginalFilename(),
                 postId);
         } catch (IOException e) {

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImageFile.java
@@ -2,17 +2,16 @@ package com.devcourse.eggmarket.domain.model.image;
 
 import com.devcourse.eggmarket.domain.model.image.exception.InvalidFileException;
 import java.io.IOException;
-import java.io.InputStream;
 import org.springframework.web.multipart.MultipartFile;
 
-public class ProfileImage implements Image {
+public class ProfileImageFile implements ImageFile {
 
     private final ImageType type;
 	private final byte[] bytes;
     private final Long userId;
     private final String fileName;
 
-    private ProfileImage(ImageType type, byte[] bytes, Long userId,
+    private ProfileImageFile(ImageType type, byte[] bytes, Long userId,
         MultipartFile file) {
         this.type = type;
         this.bytes = bytes;
@@ -20,14 +19,14 @@ public class ProfileImage implements Image {
         this.fileName = userId.toString() + "." + file.getContentType().split("/")[1];
     }
 
-    public static ProfileImage toImage(Long userId, MultipartFile file) {
-        if (Image.isNotImage(file)) {
+    public static ProfileImageFile toImage(Long userId, MultipartFile file) {
+        if (ImageFile.isNotImage(file)) {
             throw new InvalidFileException("유효한 이미지 첨부가 아닙니다");
         }
 
         try {
 			byte[] bytes = file.getBytes();
-            return new ProfileImage(ImageType.PROFILE, bytes, userId, file);
+            return new ProfileImageFile(ImageType.PROFILE, bytes, userId, file);
         } catch (IOException e) {
 			throw new InvalidFileException("업로드된 Profile 파일을 읽어오는데 실패하였습니다");
         }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -6,6 +6,7 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
 import java.net.URI;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +33,7 @@ public class PostController {
     }
 
     @PostMapping
-    ResponseEntity<Long> write(@RequestBody PostRequest.Save request,
+    ResponseEntity<Long> write(@Valid PostRequest.Save request,
         Authentication authentication) {
         Long postId = postService.save(request, authentication.getName());
         final URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostRequest.java
@@ -18,10 +18,12 @@ import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.PostStatus;
 import com.devcourse.eggmarket.global.common.ValueOfEnum;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 public class PostRequest {
 
@@ -40,7 +42,9 @@ public class PostRequest {
         @NotBlank(message = NOT_BLANK_CATEGORY)
         @Size(min = 1, max = 20, message = NOT_VALID_RANGE_CATEGORY)
         @ValueOfEnum(enumClass = Category.class, message = NOT_VALID_CATEGORY)
-        String category
+        String category,
+
+        List<MultipartFile> images
     ) {
 
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
@@ -1,0 +1,46 @@
+package com.devcourse.eggmarket.domain.post.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false, updatable = false)
+    private Post post;
+
+    @Column(length = 100, nullable = false)
+    private String imagePath;
+
+    @Builder
+    public PostImage(Long id, Post post, String imagePath) {
+        this.id = id;
+        this.post = post;
+        this.imagePath = imagePath;
+    }
+
+    public PostImage(Post post, String imagePath) {
+        this(null, post, imagePath);
+    }
+
+    public String getImagePath() {
+        return imagePath;
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
@@ -1,0 +1,11 @@
+package com.devcourse.eggmarket.domain.post.repository;
+
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    List<PostImage> findByPost(Post post);
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -3,6 +3,9 @@ package com.devcourse.eggmarket.domain.post.service;
 import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage.NOT_EXIST_POST;
 import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage.NOT_MATCHED_SELLER_POST;
 
+import com.devcourse.eggmarket.domain.model.image.ImageFile;
+import com.devcourse.eggmarket.domain.model.image.ImageUpload;
+import com.devcourse.eggmarket.domain.model.image.PostImageFile;
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
@@ -10,10 +13,14 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
+import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,44 +31,53 @@ public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
 
+    private final PostImageRepository postImageRepository;
+
     private final UserService userService;
 
     private final PostConverter postConverter;
 
+    private final ImageUpload imageUpload;
+
     public PostServiceImpl(PostRepository postRepository,
+        PostImageRepository postImageRepository,
         UserService userService,
-        PostConverter postConverter) {
+        PostConverter postConverter,
+        ImageUpload imageUpload) {
         this.postRepository = postRepository;
+        this.postImageRepository = postImageRepository;
         this.userService = userService;
         this.postConverter = postConverter;
-    }
-
-    private Post checkPostWriter(Long postId, String loginUser) {
-        Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, postId));
-        Long loginUserId = userService.getUser(loginUser).getId();
-        Long sellerId = post.getSeller().getId();
-        if (!(sellerId.equals(loginUserId))) {
-            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, sellerId, loginUserId);
-        }
-
-        return post;
+        this.imageUpload = imageUpload;
     }
 
     @Transactional
     @Override
     public Long save(PostRequest.Save request, String loginUser) {
+        Order order = new Order();
         User seller = userService.getUser(loginUser);
-        Post post = postConverter.saveToPost(request, seller);
 
-        return postRepository.save(post).getId();
+        Post savedPost = postRepository.save(
+            postConverter.saveToPost(request, seller)
+        );
+
+        Optional.ofNullable(request.images())
+            .orElse(Collections.emptyList()).stream()
+            .map(img -> PostImageFile.toImage(savedPost.getId(), img, order.order()))
+            .forEach(file -> uploadFile(savedPost, file));
+
+        // TODO : 이미지 개수 , HttpRequest 용량 관련 에러 처리
+
+        return savedPost.getId();
     }
 
     @Transactional
     @Override
     public Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser) {
         Post post = checkPostWriter(id, loginUser);
+
         postConverter.updateToPost(request, post);
+
         return post.getId();
     }
 
@@ -96,5 +112,56 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostResponse.SinglePost> getAllByCategory(Pageable pageable, String category) {
         return null;
+    }
+
+    private String uploadFile(Post post, ImageFile file) {
+        return postImageRepository.save(
+            PostImage.builder()
+                .post(post)
+                .imagePath(imageUpload.upload(file))
+                .build()
+        ).getImagePath();
+    }
+
+    private Post checkPostWriter(Long postId, String loginUser) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, postId));
+        Long loginUserId = userService.getUser(loginUser).getId();
+        Long sellerId = post.getSeller().getId();
+        if (!(sellerId.equals(loginUserId))) {
+            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, sellerId, loginUserId);
+        }
+
+        return post;
+    }
+
+    private static class Order {
+
+        private final Sequence order;
+
+        private Order(Sequence order) {
+            this.order = order;
+        }
+
+        public Order() {
+            this(new Sequence());
+        }
+
+        public int order() {
+            int pre = this.order.order;
+
+            this.order.increase();
+
+            return pre;
+        }
+
+        private static class Sequence {
+
+            private int order = 0;
+
+            public void increase() {
+                this.order++;
+            }
+        }
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
@@ -1,15 +1,11 @@
 package com.devcourse.eggmarket.domain.user.converter;
 
-import com.devcourse.eggmarket.domain.model.image.ImageUpload;
-import com.devcourse.eggmarket.domain.model.image.ProfileImage;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
-import org.springframework.context.ApplicationContext;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class UserConverter {

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
@@ -1,8 +1,8 @@
 package com.devcourse.eggmarket.domain.user.service;
 
-import com.devcourse.eggmarket.domain.model.image.Image;
+import com.devcourse.eggmarket.domain.model.image.ImageFile;
 import com.devcourse.eggmarket.domain.model.image.ImageUpload;
-import com.devcourse.eggmarket.domain.model.image.ProfileImage;
+import com.devcourse.eggmarket.domain.model.image.ProfileImageFile;
 import com.devcourse.eggmarket.domain.user.converter.UserConverter;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
@@ -39,8 +39,8 @@ public class DefaultUserService implements UserService {
     public UserResponse save(Save userRequest) {
         User user = userRepository.save(userConverter.saveToUser(userRequest));
         if (userRequest.profileImage() != null) {
-            Image image = ProfileImage.toImage(user.getId(), userRequest.profileImage());
-            user.setImagePath(imageUpload.upload(image));
+            ImageFile imageFile = ProfileImageFile.toImage(user.getId(), userRequest.profileImage());
+            user.setImagePath(imageUpload.upload(imageFile));
         }
         return userConverter.convertToUserResponse(user);
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/model/image/LocalImageUploadTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/model/image/LocalImageUploadTest.java
@@ -22,7 +22,7 @@ class LocalImageUploadTest {
     ImageLocalPathProperties pathProperties;
 
     private ImageUpload imageUpload;
-    private Image postImage;
+    private ImageFile postImageFile;
 
     private String pathSaved;
 
@@ -45,9 +45,9 @@ class LocalImageUploadTest {
         MultipartFile multipartFile2 = new MockMultipartFile(name2, savedPath.toString(),
             contentType, inputStream2);
 
-        PostImage savedPostImage = PostImage.toImage(1, multipartFile2, 4);
+        PostImageFile savedPostImage = PostImageFile.toImage(1, multipartFile2, 4);
 
-        this.postImage = PostImage.toImage(1, multipartFile, 2);
+        this.postImageFile = PostImageFile.toImage(1, multipartFile, 2);
         this.imageUpload = new LocalImageUpload(pathProperties);
         this.pathSaved = this.imageUpload.upload(savedPostImage);
     }
@@ -55,7 +55,7 @@ class LocalImageUploadTest {
     @Test
     @DisplayName("PostImage 를 서버에 저장한다")
     public void uploadTest() {
-        String uploadedPath = imageUpload.upload(postImage);
+        String uploadedPath = imageUpload.upload(postImageFile);
 
         Assertions.assertThat(Files.exists(Path.of(uploadedPath))).isTrue();
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/model/image/PostImageFileTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/model/image/PostImageFileTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
-class PostImageTest {
+class PostImageFileTest {
 
     private MockMultipartFile multipartFile;
 
@@ -30,7 +30,7 @@ class PostImageTest {
     @Test
     @DisplayName("Post id 와 해당 파일의 순서와 Multipartfile 이 주어지면, post id와 순서로 유니크한 경로를 만들어낼 수 있는 PostImage 를 생성한다")
     public void createPostImage() {
-        PostImage postImage = PostImage.toImage(1, multipartFile, 2);
+        PostImageFile postImage = PostImageFile.toImage(1, multipartFile, 2);
 
         Assertions.assertThat(postImage.pathTobeStored("foo"))
             .isEqualTo("foo/1_2.png");

--- a/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/converter/PostConverterTest.java
@@ -24,7 +24,8 @@ class PostConverterTest {
             "title",
             "content",
             1000,
-            "BEAUTY"
+            "BEAUTY",
+            null
         );
         User seller = User.builder()
             .nickName("test")

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.devcourse.eggmarket.domain.post.repository;
+
+import com.devcourse.eggmarket.domain.post.model.Category;
+import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
+import com.devcourse.eggmarket.domain.user.model.User;
+import com.devcourse.eggmarket.domain.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@DataJpaTest
+@EnableJpaAuditing
+class PostImageRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostImageRepository postImageRepository;
+
+    private User writer;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        writer = User.builder()
+            .phoneNumber("123456789")
+            .nickName("user01")
+            .password("User01234*")
+            .role("USER")
+            .build();
+
+        post = Post.builder()
+            .title("title01")
+            .content("content01")
+            .seller(writer)
+            .price(1000)
+            .category(Category.BEAUTY)
+            .build();
+
+        userRepository.save(writer);
+        postRepository.save(post);
+    }
+
+    @Test
+    @DisplayName("인자로 전달받은 판매글에 대한 이미지 경로들을 가져올 수 있다")
+    public void findByPost() {
+        // when
+        String[] givenImgPathArray = new String[]{"/src/post/1_1.png", "/src/post/1_2.png"};
+
+        List<PostImage> postImgPaths = Arrays.stream(givenImgPathArray)
+            .map(path -> postImageRepository.save(
+                new PostImage(post, path)
+            )).toList();
+
+        // given
+        List<PostImage> foundImgPaths = postImageRepository.findByPost(post);
+
+        // then
+        Assertions.assertThat(foundImgPaths.size())
+            .isEqualTo(givenImgPathArray.length);
+    }
+}

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -1,7 +1,6 @@
 package com.devcourse.eggmarket.domain.stub;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
-import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePost;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.user.model.User;

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -16,7 +16,8 @@ public class PostStub {
             "title",
             "content",
             1000,
-            "BEAUTY"
+            "BEAUTY",
+            null
         );
     }
 
@@ -25,7 +26,8 @@ public class PostStub {
             "title",
             "content",
             1000,
-            "FOOD"
+            "FOOD",
+            null
         );
     }
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- Image 인터페이스 및 Image 구현체들 이름 변경 -> ImageFile
- PostImage 엔티티 추가 
- PostImageRepository 추가
- form-data 를 통한 요청만을 받기 때문에, @ResponseBody 를 제거하였습니다
- 판매글 작성 로직 변경 (이미지 업로드를 추가하였음)
- PostServiceImpl 에서 private 메소드의 위치는 아래쪽으로 이동시켰습니다 ( 코드컨벤션)
- 이미지 업로드시 postid_순서  라는 이름으로 저장하다보니, 순차적으로 증가하는 순서가 필요하여 Order 객체를 정의하여 사용하였습니다

## 필요한 부분
- 이미지 파일 크기 초과에 따른 오류는 servlet 단에서 발생하여, 예외처리에 대한 어려움을 느끼고 있습니다. 해당 예외는 GlobalExceptionHandler 에서 바로 잡아서 처리하는 것으로 해도 되는지에 대해 의논이 필요합니다 

## 작업으로 인해 해결된 이슈 번호
- EM-56