### PR TITLE
✨ feat : 판매글 페이지 조회 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -4,12 +4,18 @@ import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
+import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
+import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.net.URI;
 import javax.validation.Valid;
+import java.util.Optional;
+import javax.validation.constraints.Size;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,10 +23,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
+@Validated
 @RequestMapping("/posts")
 public class PostController {
 
@@ -47,7 +55,7 @@ public class PostController {
     }
 
     @PatchMapping("/{id}/post")
-    ResponseEntity<Long> updatePost(@RequestBody PostRequest.UpdatePost request,
+    ResponseEntity<Long> updatePost(@RequestBody @Valid PostRequest.UpdatePost request,
         Authentication authentication,
         @PathVariable Long id) {
         Long postId = postService.updatePost(id, request, authentication.getName());
@@ -56,7 +64,7 @@ public class PostController {
     }
 
     @PatchMapping("/{id}/purchase")
-    ResponseEntity<Long> updatePurchase(@RequestBody PostRequest.UpdatePurchaseInfo request,
+    ResponseEntity<Long> updatePurchase(@RequestBody @Valid PostRequest.UpdatePurchaseInfo request,
         Authentication authentication,
         @PathVariable Long id) {
         Long postId = postService.updatePurchaseInfo(id, request, authentication.getName());
@@ -89,5 +97,12 @@ public class PostController {
     ResponseEntity<PostResponse.SinglePost> getPost(@PathVariable Long id, Authentication authentication) {
         PostResponse.SinglePost response = postService.getById(id, authentication.getName());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    ResponseEntity<PostResponse.Posts> getPosts(Pageable pageable) {
+        return ResponseEntity.ok(
+            postService.getAll(pageable)
+        );
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -78,4 +78,19 @@ public class PostConverter {
         );
 
     }
+
+    public PostResponse.PostsElement convertToPostsElement(Post post) {
+        return new PostsElement(
+            post.getId(),
+            post.getPrice(),
+            post.getTitle(),
+            post.getPostStatus().toString(),
+            post.getCreatedAt(),
+            post.getAttentionCount(),
+            0, // TODO : 커멘트 개수 post 에서 가져오기
+            null
+        );
+
+    }
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
@@ -3,9 +3,11 @@ package com.devcourse.eggmarket.domain.post.repository;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostImage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     List<PostImage> findByPost(Post post);
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.model.Category;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -19,7 +20,7 @@ public interface PostService {
 
     PostResponse.SinglePost getById(Long id, String loginUser);
 
-    List<PostResponse.SinglePost> getAll(Pageable pageable);
+    PostResponse.Posts getAll(Pageable pageable);
 
-    List<PostResponse.SinglePost> getAllByCategory(Pageable pageable, String category);
+    PostResponse.Posts getAllByCategory(Pageable pageable, String category);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -10,6 +10,8 @@ import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
@@ -95,7 +97,6 @@ public class PostServiceImpl implements PostService {
         return post.getId();
     }
 
-
     @Transactional
     @Override
     public void deleteById(Long id, String loginUser) {
@@ -115,13 +116,15 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostResponse.SinglePost> getAll(Pageable pageable) {
-        return null;
+    public PostResponse.Posts getAll(Pageable pageable) {
+        return new Posts(postRepository.findAll(pageable)
+            .map(this::postResponseAddImage)
+            .getContent()
+        );
     }
 
-
     @Override
-    public List<PostResponse.SinglePost> getAllByCategory(Pageable pageable, String category) {
+    public PostResponse.Posts getAllByCategory(Pageable pageable, String category) {
         return null;
     }
 
@@ -174,5 +177,15 @@ public class PostServiceImpl implements PostService {
                 this.order++;
             }
         }
+    }
+
+    private PostsElement postResponseAddImage(Post post) {
+        String path = "";
+
+        List<PostImage> images = postImageRepository.findByPost(post);
+        if (!images.isEmpty()) {
+            path = images.get(0).getImagePath();
+        }
+        return postConverter.postsElement(post, path);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -18,23 +18,32 @@ import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
+import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.stub.PostStub;
 import com.devcourse.eggmarket.domain.stub.UserStub;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceImplTest {
 
     @InjectMocks
+    @Spy
     PostServiceImpl postService;
 
     @Mock
@@ -48,6 +57,9 @@ class PostServiceImplTest {
 
     @Mock
     PostAttentionRepository postAttentionRepository;
+
+    @Mock
+    PostImageRepository postImageRepository;
 
     @Test
     @DisplayName("판매글 생성 테스트")
@@ -283,5 +295,35 @@ class PostServiceImplTest {
 
         assertThatExceptionOfType(NotExistPostException.class)
             .isThrownBy(() -> postService.getById(request, loginUser));
+    }
+
+    @Test
+    @DisplayName("최신순으로 게시글 조회")
+    void getAllLatestTest() {
+        Pageable request = PageRequest.of(0, 3);
+        PostResponse.Posts response = PostStub.posts();
+
+        doReturn(response)
+            .when(postService)
+            .getAll(request);
+
+        assertThat(postService.getAll(request))
+            .usingRecursiveComparison()
+            .isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("가격순으로 게시글 조회")
+    void getAllPriceTest() {
+        Pageable request = PageRequest.of(0, 3, Sort.by("price"));
+        PostResponse.Posts response = PostStub.priceSortPosts();
+
+        doReturn(response)
+            .when(postService)
+            .getAll(request);
+
+        assertThat(postService.getAll(request))
+            .usingRecursiveComparison()
+            .isEqualTo(response);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -2,11 +2,15 @@ package com.devcourse.eggmarket.domain.stub;
 
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.SinglePost;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class PostStub {
 
@@ -92,6 +96,80 @@ public class PostStub {
             0,
             true,
             null
+        );
+    }
+
+    public static PostResponse.Posts posts() {
+        return new PostResponse.Posts(
+            List.of(
+                new PostsElement(
+                    1L,
+                    1000,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                ),
+                new PostsElement(
+                    2L,
+                    500,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                ),
+                new PostsElement(
+                    1L,
+                    2500,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                )
+            )
+        );
+    }
+
+    public static Posts priceSortPosts() {
+        return new PostResponse.Posts(
+            List.of(
+                new PostsElement(
+                    2L,
+                    500,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                ),
+                new PostsElement(
+                    1L,
+                    1000,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                ),
+                new PostsElement(
+                    3L,
+                    2500,
+                    "title",
+                    "COMPLETED",
+                    LocalDateTime.now(),
+                    0,
+                    0,
+                    null
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 가격순, 최신순(default) 페이지 조회 기능 추가
- 판매글 조회 테스트 코드 추가
- 판매글 페이지 조회시 대표 이미지 포함하여(가장 처음 이미지) 조회하도록 구현

## 이슈 번호
- EM-21

## 문제 사항
- PostConverter 매핑시 람다식 사용으로 인한 테스트 코드 작성의 어려움으로 Service를 Spy 객체로 사용하여 작성했습니다.