### PR TITLE
✨ feat : 판매글을 카테고리로 페이지 조회 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -7,15 +7,12 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
-import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.net.URI;
-import javax.validation.Valid;
 import java.util.Optional;
-import javax.validation.constraints.Size;
+import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
-@Validated
 @RequestMapping("/posts")
 public class PostController {
 
@@ -94,15 +90,20 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    ResponseEntity<PostResponse.SinglePost> getPost(@PathVariable Long id, Authentication authentication) {
+    ResponseEntity<PostResponse.SinglePost> getPost(@PathVariable Long id,
+        Authentication authentication) {
         PostResponse.SinglePost response = postService.getById(id, authentication.getName());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping
-    ResponseEntity<PostResponse.Posts> getPosts(Pageable pageable) {
+    ResponseEntity<PostResponse.Posts> getPosts(Pageable pageable,
+        @RequestParam Optional<Category> category) {
         return ResponseEntity.ok(
-            postService.getAll(pageable)
+            category.isPresent() ?
+                postService.getAllByCategory(pageable, category.get()) :
+                postService.getAll(pageable)
         );
     }
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -7,12 +7,14 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
+import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.net.URI;
 import java.util.Optional;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
+@Validated
 @RequestMapping("/posts")
 public class PostController {
 
@@ -98,10 +101,10 @@ public class PostController {
 
     @GetMapping
     ResponseEntity<PostResponse.Posts> getPosts(Pageable pageable,
-        @RequestParam Optional<Category> category) {
+        @RequestParam(required = false) @ValueOfEnum(enumClass = Category.class) String category) {
         return ResponseEntity.ok(
-            category.isPresent() ?
-                postService.getAllByCategory(pageable, category.get()) :
+            category != null ?
+                postService.getAllByCategory(pageable, Category.valueOf(category)) :
                 postService.getAll(pageable)
         );
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/converter/PostConverter.java
@@ -76,7 +76,6 @@ public class PostConverter {
             post.getCommentCount(),
             imgPath
         );
-
     }
 
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
@@ -1,7 +1,11 @@
 package com.devcourse.eggmarket.domain.post.repository;
 
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
+import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         + "inner join fetch p.seller "
         + "WHERE pa.user.id = :userId")
     List<Post> findAllLikedBy(@Param("userId") Long userId);
+
+    Page<Post> findAllByCategory(Pageable pageable, Category category);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -22,5 +22,5 @@ public interface PostService {
 
     PostResponse.Posts getAll(Pageable pageable);
 
-    PostResponse.Posts getAllByCategory(Pageable pageable, String category);
+    PostResponse.Posts getAllByCategory(Pageable pageable, Category category);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -14,6 +14,7 @@ import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
+import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
@@ -124,8 +125,11 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostResponse.Posts getAllByCategory(Pageable pageable, String category) {
-        return null;
+    public PostResponse.Posts getAllByCategory(Pageable pageable, Category category) {
+        return new Posts(postRepository.findAllByCategory(pageable, category)
+            .map(this::postResponseAddThumbnail)
+            .getContent()
+        );
     }
 
     private String uploadFile(Post post, ImageFile file) {

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -16,6 +16,7 @@ import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
+import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
@@ -323,6 +324,22 @@ class PostServiceImplTest {
             .getAll(request);
 
         assertThat(postService.getAll(request))
+            .usingRecursiveComparison()
+            .isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("카테고리로 게시글 조회")
+    void getAllByCategoryTest() {
+        Pageable request = PageRequest.of(0, 3);
+        Category category = Category.DIGITAL;
+        PostResponse.Posts response = PostStub.posts();
+
+        doReturn(response)
+            .when(postService)
+            .getAllByCategory(request, category);
+
+        assertThat(postService.getAllByCategory(request, category))
             .usingRecursiveComparison()
             .isEqualTo(response);
     }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- url query를 통해 카테고리를 지정하여 해당 카테고리만 검색되도록 구현
- 테스트 코드 작성

## 이슈 번호
- EM-24

## 문제사항
- 카테고리를 넣어도 안넣어도 상관없게 하기 위해 optional을 사용했는데 이로인해 이전에 사용하던 Enum 체크 방식을 사용하기 힘들어졌습니다. (Optional로 묶여 있기 때문에)
그래서 현재 Validation에서 발생하지 않고 Jackson에서 Mapping 실패하는 예외로 발생합니다.