### PR TITLE
🧪 test : 판매글 작성에 대한 컨트롤러 테스트 추가

### DIFF
--- a/docs/post-api.adoc
+++ b/docs/post-api.adoc
@@ -1,0 +1,43 @@
+:hardbreaks:
+ifndef::snippets[]
+:snippets: ../../../target/generated-snippets
+endif::[]
+
+= 판매글 관리
+
+== 판매글 생성
+
+=== POST /posts
+
+.Request
+include::{snippets}/post-write/http-request.adoc[]
+include::{snippets}/post-write/request-parameters.adoc[]
+include::{snippets}/post-write/request-parts.adoc[]
+
+.Response
+include::{snippets}/post-write/http-response.adoc[]
+include::{snippets}/post-write/response-fields.adoc[]
+
+== 판매글 내용 업데이트
+
+=== PATCH /posts/{id}
+
+.Request
+include::{snippets}/post-update/http-request.adoc[]
+include::{snippets}/post-update/request-fields.adoc[]
+
+.Response
+include::{snippets}/post-update/http-response.adoc[]
+include::{snippets}/post-update/response-fields.adoc[]
+
+== 판매글 상태 업데이트
+
+=== PATCH /posts/{id}/purchase
+
+.Request
+include::{snippets}/post-update/http-request.adoc[]
+include::{snippets}/post-update/request-fields.adoc[]
+
+.Response
+include::{snippets}/post-update/http-response.adoc[]
+include::{snippets}/post-update/response-fields.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.5.12</version>
         </dependency>
 
         <dependency>
@@ -79,19 +78,16 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>5.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>5.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -40,34 +40,34 @@ public class PostController {
     }
 
     @PostMapping
-    ResponseEntity<Long> write(@Valid PostRequest.Save request,
+    ResponseEntity<PostResponse.Save> write(@Valid PostRequest.Save request,
         Authentication authentication) {
-        Long postId = postService.save(request, authentication.getName());
+        PostResponse.Save response = postService.save(request, authentication.getName());
         final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{id}")
-            .buildAndExpand(postId)
+            .buildAndExpand(response)
             .toUri();
 
         return ResponseEntity.created(location)
-            .body(postId);
+            .body(response);
     }
 
     @PatchMapping("/{id}")
-    ResponseEntity<Long> updatePost(@RequestBody PostRequest.UpdatePost request,
+    ResponseEntity<PostResponse.Update> updatePost(@RequestBody PostRequest.UpdatePost request,
         Authentication authentication,
         @PathVariable Long id) {
-        Long postId = postService.updatePost(id, request, authentication.getName());
+        PostResponse.Update response = postService.updatePost(id, request, authentication.getName());
 
-        return ResponseEntity.ok(postId);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{id}/purchase")
-    ResponseEntity<Long> updatePurchase(@RequestBody @Valid PostRequest.UpdatePurchaseInfo request,
+    ResponseEntity<PostResponse.Update> updatePurchase(@RequestBody @Valid PostRequest.UpdatePurchaseInfo request,
         Authentication authentication,
         @PathVariable Long id) {
-        Long postId = postService.updatePurchaseInfo(id, request, authentication.getName());
+        PostResponse.Update response = postService.updatePurchaseInfo(id, request, authentication.getName());
 
-        return ResponseEntity.ok(postId);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostResponse.java
@@ -46,4 +46,12 @@ public class PostResponse {
     public record Posts(List<PostsElement> posts) {
 
     }
+
+    public record Save(Long id) {
+
+    }
+
+    public record Update(Long id) {
+
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -10,11 +10,11 @@ import org.springframework.security.core.Authentication;
 
 public interface PostService {
 
-    Long save(Save request, String loginUser);
+    PostResponse.Save save(Save request, String loginUser);
 
-    Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser);
+    PostResponse.Update updatePost(Long id, PostRequest.UpdatePost request, String loginUser);
 
-    Long updatePurchaseInfo(Long id, PostRequest.UpdatePurchaseInfo request, String loginUser);
+    PostResponse.Update updatePurchaseInfo(Long id, PostRequest.UpdatePurchaseInfo request, String loginUser);
 
     void deleteById(Long id, String loginUser);
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -13,6 +13,7 @@ import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Update;
 import com.devcourse.eggmarket.domain.post.exception.InvalidBuyerException;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
@@ -68,7 +69,7 @@ public class PostServiceImpl implements PostService {
 
     @Transactional
     @Override
-    public Long save(PostRequest.Save request, String loginUser) {
+    public PostResponse.Save save(PostRequest.Save request, String loginUser) {
         Order order = new Order();
         User seller = userService.getUser(loginUser);
 
@@ -83,29 +84,28 @@ public class PostServiceImpl implements PostService {
 
         // TODO : 이미지 개수 , HttpRequest 용량 관련 에러 처리
 
-        return savedPost.getId();
+        return new PostResponse.Save(savedPost.getId());
     }
 
     @Transactional
     @Override
-    public Long updatePost(Long id, PostRequest.UpdatePost request, String loginUser) {
+    public PostResponse.Update updatePost(Long id, PostRequest.UpdatePost request, String loginUser) {
         Post post = checkPostWriter(id, loginUser);
 
         postConverter.updateToPost(request, post);
 
-        return post.getId();
+        return new PostResponse.Update(post.getId());
     }
 
     @Transactional
     @Override
-    public Long updatePurchaseInfo(Long id, UpdatePurchaseInfo request, String loginUser) {
+    public PostResponse.Update updatePurchaseInfo(Long id, UpdatePurchaseInfo request, String loginUser) {
         Post post = checkPostWriter(id, loginUser);
         User buyer = userService.getById(request.buyerId());
 
         checkAllowedBuyer(buyer, post);
-
         postConverter.updateToPurchase(request, post, buyer);
-        return post.getId();
+        return new PostResponse.Update(post.getId());
     }
 
     @Transactional

--- a/src/main/java/com/devcourse/eggmarket/global/aop/LoggingAspect.java
+++ b/src/main/java/com/devcourse/eggmarket/global/aop/LoggingAspect.java
@@ -18,9 +18,10 @@ public class LoggingAspect {
         long startTime = System.nanoTime();
         Object result = joinPoint.proceed();
         long endTime = System.nanoTime() - startTime;
-        logger.info("[{}] After method called with result => {} as time taken {} ns", layer, result, endTime);
+        logger.info("[{}] After method called with result => {} as time taken {} ns", layer, result,
+            endTime);
         return result;
-}
+    }
 
     @Around("com.devcourse.eggmarket.global.aop.CommonPointcut.controllerPublicMethodPointcut()")
     public Object controllerLog(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -29,11 +30,11 @@ public class LoggingAspect {
 
     @Around("com.devcourse.eggmarket.global.aop.CommonPointcut.servicePublicMethodPointcut()")
     public Object serviceLog(ProceedingJoinPoint joinPoint) throws Throwable {
-            return loggingFormat(joinPoint, "Service");
-        }
+        return loggingFormat(joinPoint, "Service");
+    }
 
-        @Around("com.devcourse.eggmarket.global.aop.CommonPointcut.repositoryPublicMethodPointcut()")
-        public Object repositoryLog(ProceedingJoinPoint joinPoint) throws Throwable {
-            return loggingFormat(joinPoint, "Repository");
+    @Around("com.devcourse.eggmarket.global.aop.CommonPointcut.repositoryPublicMethodPointcut()")
+    public Object repositoryLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        return loggingFormat(joinPoint, "Repository");
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/global/error/ErrorResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/ErrorResponse.java
@@ -10,13 +10,14 @@ public class ErrorResponse {
     private String code;
     private String message;
 
-    private ErrorResponse(final ErrorCode code) {
+    public ErrorResponse(final ErrorCode code) {
         this.code = code.getCode();
         this.message = code.getMessage();
     }
 
-    public static ErrorResponse of(final ErrorCode code) {
-        return new ErrorResponse(code);
+    public ErrorResponse(final ErrorCode code, String message) {
+        this.code = code.getCode();
+        this.message = message;
     }
 
     public String getMessage() {

--- a/src/main/java/com/devcourse/eggmarket/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/GlobalExceptionHandler.java
@@ -3,34 +3,37 @@ package com.devcourse.eggmarket.global.error;
 import com.devcourse.eggmarket.global.error.exception.BusinessException;
 import com.devcourse.eggmarket.global.error.exception.ErrorCode;
 import javax.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(
-        ConstraintViolationException e) {
-//       TODO: Logging 추가
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT);
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.warn("{}", e.getMessage());
+        final ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_INPUT, e.getMessage());
         return ResponseEntity.badRequest().body(response);
     }
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-//       TODO: Logging 추가
+        log.error("{}", e.getMessage());
         final ErrorCode errorCode = e.getErrorCode();
-        final ErrorResponse response = ErrorResponse.of(errorCode);
+        final ErrorResponse response = new ErrorResponse(errorCode);
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        //       TODO: Logging 추가
-        System.out.println(e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        log.error("{}", e.getMessage());
+        final ErrorResponse response = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.internalServerError().body(response);
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/exception/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
     // comment error
     SOLD_OUT_POST_NOT_ALLOWED_COMMENT_ERROR("C01", "판매 완료된 글에는 댓글을 작성할 수 없습니다",
         HttpStatus.FORBIDDEN),
-    NOT_ALLOWED_BUYER("C02", "해당 판매글에 대한 구매자로 등록할 수 없습니다", HttpStatus.BAD_REQUEST);
+    NOT_ALLOWED_BUYER("C02", "해당 판매글에 대한 구매자로 등록할 수 없습니다", HttpStatus.BAD_REQUEST),
+
+    // post error
+    NOT_VALID_CATEGORY("P01", "존재하지 않는 카테고리 입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -1,0 +1,130 @@
+package com.devcourse.eggmarket.domain.post.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devcourse.eggmarket.domain.post.dto.PostRequest;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Save;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Update;
+import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
+import com.devcourse.eggmarket.domain.post.service.PostService;
+import com.devcourse.eggmarket.domain.stub.PostStub;
+import com.devcourse.eggmarket.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(PostController.class)
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+class PostControllerTest {
+
+    @MockBean
+    private PostService postService;
+
+    @MockBean
+    private PostAttentionService postAttentionService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    @WithMockUser
+    @DisplayName("판매글 작성 테스트")
+    void writeTest() throws Exception {
+        PostRequest.Save request = PostStub.writeRequest();
+        PostResponse.Save response = new Save(1L);
+
+        String images = "Image Files";
+        MockMultipartFile image = new MockMultipartFile("images", "img.png", "image/png",
+            images.getBytes(StandardCharsets.UTF_8));
+
+        doReturn(response)
+            .when(postService)
+            .save(any(PostRequest.Save.class), anyString());
+
+        ResultActions resultActions = mockMvc.perform(
+            multipart("/posts").file(image)
+                .param("title", request.title())
+                .param("content", request.content())
+                .param("price", String.valueOf(request.price()))
+                .param("category", request.category())
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isCreated())
+            .andDo(document("post-write",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestParameters(
+                    parameterWithName("title").description("제목"),
+                    parameterWithName("content").description("본문"),
+                    parameterWithName("price").description("가격"),
+                    parameterWithName("category").description("카테고리")
+                ),
+                requestParts(
+                    partWithName("images").description("이미지")
+                ),
+                responseFields(
+                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("게시글 ID")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("존재하지 않는 카테고리가 전달될 경우 예외가 발생하는지 테스트")
+    void invalidRequestWriteTest() throws Exception {
+        PostRequest.Save request = PostStub.invalidCategoryWriteRequest();
+        String images = "Image Files";
+        MockMultipartFile image = new MockMultipartFile("images", "img.png", "image/png",
+            images.getBytes(StandardCharsets.UTF_8));
+
+        ResultActions resultActions = mockMvc.perform(
+            multipart("/posts").file(image)
+                .param("title"," ")
+                .param("content", request.content())
+                .param("price", "aa")
+                .param("category", request.category())
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(ErrorCode.NOT_VALID_CATEGORY.getMessage()));
+    }
+
+}

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.exception.InvalidBuyerException;
 import com.devcourse.eggmarket.domain.post.model.Category;
@@ -121,7 +122,7 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("관심목록에 추가했던 로그인 사용자가 관심목록 추가 버튼을 누르면 관심목록에서 제거한다")
-    public void toggleAttentionToDisable() {
+    void toggleAttentionToDisable() {
         postAttentionService.toggleAttention(writerLikedOwnPost.getNickName(), likedPost1.getId());
 
         boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(likedPost1.getId(),
@@ -133,7 +134,7 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("관심목록에 추가한 적 없던 로그인 사용자가 관심목록 추가 버튼을 누르면 관심목록에 추가한다")
-    public void toggleAttentionToEnable() {
+    void toggleAttentionToEnable() {
         postAttentionService.toggleAttention(notYetLikedUser.getNickName(), likedPost1.getId());
 
         boolean afterLikeOfMe = postAttentionRepository.findByPostIdAndUserId(likedPost1.getId(),
@@ -145,7 +146,7 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("로그인 사용자는 자신의 관심목록을 확인한다")
-    public void getAllLikedPosts() {
+    void getAllLikedPosts() {
         Posts allLikedPosts = postAttentionService.getAllLikedBy(
             writerLikedOwnPost.getNickName());
 
@@ -154,7 +155,7 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("판매글에 대한 댓글 작성자가 아니면 판매글의 구매자로 등록될 수 없다")
-    public void updatePostInfoFail() {
+    void updatePostInfoFail() {
         UpdatePurchaseInfo updatePurchaseRequest = new UpdatePurchaseInfo(
             PostStatus.COMPLETED.name(),
             notCommentWriter.getId());
@@ -169,7 +170,7 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("판매글 작성자는 판매글의 구매자로 등록될 수 없다")
-    public void updatePostInfoFailWithSeller() {
+    void updatePostInfoFailWithSeller() {
         UpdatePurchaseInfo updatePurchaseRequest = new UpdatePurchaseInfo(
             PostStatus.COMPLETED.name(),
             writerLikedOwnPost.getId());
@@ -184,16 +185,16 @@ public class PostServiceIntegrationTest {
 
     @Test
     @DisplayName("판매글에 대한 댓글 작성자는 판매글의 구매자로 등록할 수 있다")
-    public void updatePostInfoSuccess() {
+    void updatePostInfoSuccess() {
         UpdatePurchaseInfo updatePurchaseRequest = new UpdatePurchaseInfo(
             PostStatus.COMPLETED.name(),
             commentWriter.getId());
 
-        Long soldPostId = postService.updatePurchaseInfo(
+        PostResponse.Update response = postService.updatePurchaseInfo(
             likedPost1.getId(),
             updatePurchaseRequest,
             likedPost1.getSeller().getNickName());
 
-        Assertions.assertThat(soldPostId).isEqualTo(likedPost1.getId());
+        Assertions.assertThat(response.id()).isEqualTo(likedPost1.getId());
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -33,7 +33,7 @@ public class PostStub {
             "title",
             "content",
             1000,
-            "FOOD",
+            "BEAUTY",
             null
         );
     }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 컨트롤러 계층에서 판매글 작성과 잘못된 파라미터 전달시에 대한 예외 테스트 추가
- 예외 메시지를 가져오기 위해 global exception과 ErrorResponse 수정
- Wrapper Class 사용시 restdocs 작성이 안되는 문제로 인한 Response DTO 추가
- restdocs 설정 완료

## 이슈 번호
- EM-18