### PR TITLE
🧪 test : 판매글 수정 관련 컨트롤러 테스트 코드 작성

### DIFF
--- a/docs/post-api.adoc
+++ b/docs/post-api.adoc
@@ -35,9 +35,9 @@ include::{snippets}/post-update/response-fields.adoc[]
 === PATCH /posts/{id}/purchase
 
 .Request
-include::{snippets}/post-update/http-request.adoc[]
-include::{snippets}/post-update/request-fields.adoc[]
+include::{snippets}/post-update-purchase/http-request.adoc[]
+include::{snippets}/post-update-purchase/request-fields.adoc[]
 
 .Response
-include::{snippets}/post-update/http-response.adoc[]
-include::{snippets}/post-update/response-fields.adoc[]
+include::{snippets}/post-update-purchase/http-response.adoc[]
+include::{snippets}/post-update-purchase/response-fields.adoc[]

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -54,7 +54,7 @@ public class PostController {
     }
 
     @PatchMapping("/{id}")
-    ResponseEntity<SuccessResponse<Long>> updatePost(@RequestBody PostRequest.UpdatePost request,
+    ResponseEntity<SuccessResponse<Long>> updatePost(@RequestBody @Valid PostRequest.UpdatePost request,
         Authentication authentication,
         @PathVariable Long id) {
         Long response = postService.updatePost(id, request, authentication.getName());

--- a/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/dto/PostRequest.java
@@ -21,6 +21,7 @@ import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
@@ -76,7 +77,7 @@ public class PostRequest {
         String postStatus,
 
         @NotNull(message = NOT_NULL_USER)
-        @PositiveOrZero(message = NOT_NEGATIVE_ID)
+        @Positive(message = NOT_NEGATIVE_ID)
         Long buyerId
     ) {
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/exception/PostExceptionMessage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/exception/PostExceptionMessage.java
@@ -21,7 +21,7 @@ public class PostExceptionMessage {
 
     public static final String NOT_NEGATIVE_PRICE = "가격은 음수일 수 없습니다";
 
-    public static final String NOT_NEGATIVE_ID = "아이디는 음수일 수 없습니다";
+    public static final String NOT_NEGATIVE_ID = "아이디는 양수여야 합니다.";
 
     public static final String NOT_VALID_RANGE_CATEGORY = "카테고리는 1 ~ 20자 이어야 합니다";
 

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.devcourse.eggmarket.domain.post.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -9,6 +10,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
@@ -21,21 +23,24 @@ import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.service.PostAttentionService;
 import com.devcourse.eggmarket.domain.post.service.PostService;
 import com.devcourse.eggmarket.domain.stub.PostStub;
-import com.devcourse.eggmarket.global.common.SuccessResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(PostController.class)
 @AutoConfigureMockMvc
@@ -96,11 +101,11 @@ class PostControllerTest {
             ));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("com.devcourse.eggmarket.domain.stub.PostStub#invalidWriteRequest")
     @WithMockUser
-    @DisplayName("존재하지 않는 카테고리가 전달될 경우 예외가 발생하는지 테스트")
-    void invalidRequestWriteTest() throws Exception {
-        PostRequest.Save request = PostStub.invalidCategoryWriteRequest();
+    @DisplayName("판매글 생성시 잘못된 값을 전달할 경우 badRequest(400) 반환 테스트")
+    void invalidRequestWriteTest(PostRequest.Save request) throws Exception {
         String images = "Image Files";
         MockMultipartFile image = new MockMultipartFile("images", "img.png", "image/png",
             images.getBytes(StandardCharsets.UTF_8));
@@ -117,4 +122,104 @@ class PostControllerTest {
         resultActions.andExpect(status().isBadRequest());
     }
 
+    @Test
+    @WithMockUser
+    @DisplayName("판매글 수정 테스트")
+    void updatePostTest() throws Exception {
+        PostRequest.UpdatePost request = PostStub.updatePostRequest();
+        Long postId = 1L;
+
+        doReturn(postId)
+            .when(postService)
+            .updatePost(anyLong(), any(PostRequest.UpdatePost.class), anyString());
+
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch("/posts/" + postId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isOk())
+            .andDo(document("post-update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                    fieldWithPath("content").type(JsonFieldType.STRING).description("본문"),
+                    fieldWithPath("price").type(JsonFieldType.NUMBER).description("가격"),
+                    fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리")
+                ),
+                responseFields(
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("판매글 ID")
+                )
+            ));
+
+    }
+
+    @ParameterizedTest
+    @WithMockUser
+    @MethodSource("com.devcourse.eggmarket.domain.stub.PostStub#invalidUpdatePostRequest")
+    @DisplayName("판매글 수정시 잘못된 값을 전달할 경우 badRequest(400) 반환 테스트")
+    void invalidUpdatePostTest(PostRequest.UpdatePost request) throws Exception {
+        Long postId = 1L;
+
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch("/posts/" + postId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("판매글 상태변경 테스트")
+    void updatePurchaseTest() throws Exception {
+        PostRequest.UpdatePurchaseInfo request = PostStub.updatePurchaseInfo();
+        Long postId = 1L;
+
+        doReturn(postId)
+            .when(postService)
+            .updatePurchaseInfo(anyLong(), any(PostRequest.UpdatePurchaseInfo.class), anyString());
+
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch("/posts/" + postId + "/purchase")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isOk())
+            .andDo(document("post-update-purchase",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("postStatus").type(JsonFieldType.STRING).description("제목"),
+                    fieldWithPath("buyerId").type(JsonFieldType.NUMBER).description("구매자 ID")
+                ),
+                responseFields(
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("판매글 ID")
+                )
+            ));
+    }
+
+    @ParameterizedTest
+    @WithMockUser
+    @MethodSource("com.devcourse.eggmarket.domain.stub.PostStub#invalidUpdatePurchaseInfoRequest")
+    @DisplayName("판매글 상태변경시 잘못된 값을 전달할 경우 badRequest(400) 반환 테스트")
+    void invalidUpdatePurchaseTest(PostRequest.UpdatePurchaseInfo request) throws Exception {
+        Long postId = 1L;
+
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch("/posts/" + postId + "/purchase")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -11,6 +11,8 @@ import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
 
 public class PostStub {
 
@@ -172,5 +174,51 @@ public class PostStub {
             )
         );
     }
+
+    public static Stream<Arguments> invalidWriteRequest() {
+        return Stream.of(
+            Arguments.arguments(
+                new PostRequest.Save("", "content", 1000, "BEAUTY", null)
+            ),
+            Arguments.arguments(
+                new PostRequest.Save("title", "", 1000, "BEAUTY", null)
+            ),
+            Arguments.arguments(
+                new PostRequest.Save("title", "content", -1000, "BEAUTY", null)
+            ),
+            Arguments.arguments(
+                new PostRequest.Save("title", "content", 1000, "INVALID", null)
+            )
+        );
+    }
+
+    public static Stream<Arguments> invalidUpdatePostRequest() {
+        return Stream.of(
+            Arguments.arguments(
+                new PostRequest.UpdatePost("", "content", 1000, "BEAUTY")
+            ),
+            Arguments.arguments(
+                new PostRequest.UpdatePost("title", "", 1000, "BEAUTY")
+            ),
+            Arguments.arguments(
+                new PostRequest.UpdatePost("title", "content", -1000, "BEAUTY")
+            ),
+            Arguments.arguments(
+                new PostRequest.UpdatePost("title", "content", 1000, "INVALID")
+            )
+        );
+    }
+
+    public static Stream<Arguments> invalidUpdatePurchaseInfoRequest() {
+        return Stream.of(
+            Arguments.arguments(
+                new PostRequest.UpdatePurchaseInfo("COMPLTED", 0L)
+            ),
+            Arguments.arguments(
+                new PostRequest.UpdatePurchaseInfo("INVALID", 1L)
+            )
+        );
+    }
+
 }
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 작성시 valid check를 @ParameterizedTest를 사용하여 구현하도록 수정
- 판매글 본문과 상태변경 수정하는 컨트롤러 계층 테스트 코드 추가
- 컨트롤러에서 @Valid 적용
- restdocs에 판매글 수정 관련 추가

## 이슈 번호
- EM-18, EM-19