### PR TITLE
🧪 test : 판매글 삭제 컨트롤러 테스트 추가

### DIFF
--- a/docs/post-api.adoc
+++ b/docs/post-api.adoc
@@ -41,3 +41,13 @@ include::{snippets}/post-update-purchase/request-fields.adoc[]
 .Response
 include::{snippets}/post-update-purchase/http-response.adoc[]
 include::{snippets}/post-update-purchase/response-fields.adoc[]
+
+== 판매글 삭제
+
+=== DELETE /posts/{id}
+
+.Request
+include::{snippets}/post-delete/http-request.adoc[]
+
+.Response
+include::{snippets}/post-delete/http-response.adoc[]

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -222,4 +222,19 @@ class PostControllerTest {
 
         resultActions.andExpect(status().isBadRequest());
     }
+
+    @Test
+    @WithMockUser
+    @DisplayName("판매글 삭제 테스트")
+    void deleteTest() throws Exception {
+        Long request = 1L;
+
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/posts/" + request)
+                .with(csrf().asHeader())
+        );
+
+        resultActions.andExpect(status().isNoContent())
+            .andDo(document("post-delete"));
+    }
 }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 컨트롤러 계층에서 판매글 삭제시 테스트 코드 추가
- restdoc에 판매글 삭제 부분 추가

## 작업으로 인해 해결된 이슈 번호
- EM-20