### PR TITLE
♻️  refactor : 에러상황에 대한 응답 객체 재정의 및 하위 에러 객체 정의 및 구현 

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -35,5 +36,16 @@ public class CommentController {
 
         return ResponseEntity.created(location)
             .body(commentId);
+    }
+
+    @PutMapping("/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<Long> update(@PathVariable Long postId,
+        @PathVariable Long commentId, @RequestBody @Valid CommentRequest.Update updateRequest,
+        Authentication authentication) {
+
+        Long updatedCommentId = commentService.update(authentication.getName(), postId, commentId,
+            updateRequest);
+
+        return ResponseEntity.ok(updatedCommentId);
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
@@ -2,6 +2,7 @@ package com.devcourse.eggmarket.domain.comment.api;
 
 import com.devcourse.eggmarket.domain.comment.dto.CommentRequest;
 import com.devcourse.eggmarket.domain.comment.service.CommentService;
+import com.devcourse.eggmarket.global.common.SuccessResponse;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class CommentController {
     }
 
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity<Long> save(@PathVariable Long postId,
+    public ResponseEntity<SuccessResponse<Long>> save(@PathVariable Long postId,
         @RequestBody @Valid CommentRequest.Save createRequest, Authentication authentication) {
 
         Long commentId = commentService.write(authentication.getName(), postId, createRequest);
@@ -35,17 +36,18 @@ public class CommentController {
             .toUri();
 
         return ResponseEntity.created(location)
-            .body(commentId);
+            .body(new SuccessResponse<>(commentId));
     }
 
     @PutMapping("/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<Long> update(@PathVariable Long postId,
+    public ResponseEntity<SuccessResponse<Long>> update(@PathVariable Long postId,
         @PathVariable Long commentId, @RequestBody @Valid CommentRequest.Update updateRequest,
         Authentication authentication) {
 
         Long updatedCommentId = commentService.update(authentication.getName(), postId, commentId,
             updateRequest);
 
-        return ResponseEntity.ok(updatedCommentId);
+        return ResponseEntity.ok(
+            new SuccessResponse<>(updatedCommentId));
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/dto/CommentRequest.java
@@ -12,4 +12,12 @@ public class CommentRequest {
     ) {
 
     }
+
+    public record Update(
+        @NotBlank(message = "댓글을 입력해주세요")
+        @Size(max = 500)
+        String content
+    ) {
+
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,23 @@
+package com.devcourse.eggmarket.domain.comment.dto;
+
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CommentResponse {
+
+    public record Comments(
+        List<CommentsElement> comments
+    ) {
+
+    }
+
+    public record CommentsElement(
+        Long id,
+        UserResponse writer,
+        String content,
+        LocalDateTime createdAt
+    ) {
+
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/exception/NotExistCommentException.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/exception/NotExistCommentException.java
@@ -1,0 +1,12 @@
+package com.devcourse.eggmarket.domain.comment.exception;
+
+import com.devcourse.eggmarket.global.error.exception.EntityNotFoundException;
+import com.devcourse.eggmarket.global.error.exception.ErrorCode;
+
+public class NotExistCommentException extends EntityNotFoundException {
+
+    public NotExistCommentException(String message,
+        ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/exception/NotWriterException.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/exception/NotWriterException.java
@@ -1,0 +1,12 @@
+package com.devcourse.eggmarket.domain.comment.exception;
+
+import com.devcourse.eggmarket.global.error.exception.ErrorCode;
+import com.devcourse.eggmarket.global.error.exception.InvalidValueException;
+
+public class NotWriterException extends InvalidValueException {
+
+    public NotWriterException(String value,
+        ErrorCode errorCode) {
+        super(value, errorCode);
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/model/Comment.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/model/Comment.java
@@ -1,5 +1,6 @@
 package com.devcourse.eggmarket.domain.comment.model;
 
+import com.devcourse.eggmarket.domain.model.BaseEntity;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.user.model.User;
 import javax.persistence.Column;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue
@@ -48,11 +49,27 @@ public class Comment {
         this(null, post, user, content);
     }
 
+    public boolean isWriter(User user) {
+        return this.user.isSameUser(user);
+    }
+
     public Long getId() {
         return id;
     }
 
     public User getUser() {
         return user;
+    }
+
+    public void updateComment(String comment) {
+        this.content = comment;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public String getContent() {
+        return content;
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepository.java
@@ -3,9 +3,14 @@ package com.devcourse.eggmarket.domain.comment.repository;
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPost(Post post);
+
+    @Query("select c from Comment c join fetch c.post WHERE c.id = :commentId AND c.post.id = :postId")
+    Optional<Comment> findByIdAndPostId(Long commentId, Long postId);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/service/CommentService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/service/CommentService.java
@@ -1,8 +1,17 @@
 package com.devcourse.eggmarket.domain.comment.service;
 
+import com.devcourse.eggmarket.domain.comment.dto.CommentRequest;
 import com.devcourse.eggmarket.domain.comment.dto.CommentRequest.Save;
+import com.devcourse.eggmarket.domain.comment.dto.CommentResponse.Comments;
+import java.awt.print.Pageable;
 
 public interface CommentService {
 
     Long write(String userName, Long postId, Save createRequest);
+
+    Long update(String userName, Long postId, Long commentId, CommentRequest.Update updateRequest);
+
+    Comments getAllComments(String userName, Long postId, Pageable pageable);
+
+    void delete(String userName, Long postId, Long commentId);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/service/DefaultCommentService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/service/DefaultCommentService.java
@@ -4,7 +4,11 @@ import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage
 
 import com.devcourse.eggmarket.domain.comment.converter.CommentConverter;
 import com.devcourse.eggmarket.domain.comment.dto.CommentRequest.Save;
+import com.devcourse.eggmarket.domain.comment.dto.CommentRequest.Update;
+import com.devcourse.eggmarket.domain.comment.dto.CommentResponse.Comments;
 import com.devcourse.eggmarket.domain.comment.exception.CommentNotAllowedPostException;
+import com.devcourse.eggmarket.domain.comment.exception.NotExistCommentException;
+import com.devcourse.eggmarket.domain.comment.exception.NotWriterException;
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
 import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
@@ -13,9 +17,12 @@ import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
 import com.devcourse.eggmarket.global.error.exception.ErrorCode;
+import java.awt.print.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class DefaultCommentService implements CommentService {
 
     private final CommentRepository commentRepository;
@@ -37,6 +44,7 @@ public class DefaultCommentService implements CommentService {
     }
 
     @Override
+    @Transactional
     public Long write(String userName, Long postId, Save createRequest) {
         User loginUser = getLoginUser(userName);
         Post post = getExistingPost(postId);
@@ -49,9 +57,47 @@ public class DefaultCommentService implements CommentService {
         return comment.getId();
     }
 
+    @Override
+    @Transactional
+    public Long update(String userName, Long postId, Long commentId, Update updateRequest) {
+        User loginUser = getLoginUser(userName);
+        Post post = getExistingPost(postId);
+
+        Comment foundComment = getExistingComment(commentId, post);
+        checkCommentWriter(loginUser, foundComment);
+
+        return commentId;
+    }
+
+    @Override
+    public Comments getAllComments(String userName, Long postId, Pageable pageable) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public void delete(String userName, Long postId, Long commentId) {
+        // TODO
+    }
+
     private Post getExistingPost(Long postId) {
         return postRepository.findById(postId)
             .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, postId));
+    }
+
+    private Comment getExistingComment(Long commentId, Post post) {
+        return commentRepository.findByIdAndPostId(commentId, post.getId())
+            .orElseThrow(() ->
+                new NotExistCommentException(ErrorCode.ENTITY_NOT_FOUND.getMessage(),
+                    ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    private void checkCommentWriter(User loginUser, Comment comment) {
+        if (!comment.isWriter(loginUser)) {
+            throw new NotWriterException(ErrorCode.NOT_ALLOWED_USER.getMessage(),
+                ErrorCode.NOT_ALLOWED_USER);
+        }
     }
 
     private void checkNotSoldOutPost(Post post) {

--- a/src/main/java/com/devcourse/eggmarket/global/error/ErrorField.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/ErrorField.java
@@ -1,0 +1,36 @@
+package com.devcourse.eggmarket.global.error;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+public class ErrorField extends ErrorMessage {
+
+    private final String field;
+    private final String value;
+
+    public ErrorField(String field, String value, String message) {
+        super(message);
+        this.field = field;
+        this.value = value;
+    }
+
+    public static List<ErrorMessage> of(BindingResult bindingResult) {
+        return bindingResult.getAllErrors().stream()
+            .map(error ->
+                new ErrorField(
+                    ((FieldError) error).getField(),
+                    String.valueOf(((FieldError) error).getRejectedValue()),
+                    error.getDefaultMessage()))
+            .collect(Collectors.toList());
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/global/error/ErrorMessage.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.devcourse.eggmarket.global.error;
+
+public class ErrorMessage {
+
+    private final String message;
+
+    public ErrorMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/devcourse/eggmarket/global/error/ErrorResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/ErrorResponse.java
@@ -1,30 +1,37 @@
 package com.devcourse.eggmarket.global.error;
 
 import com.devcourse.eggmarket.global.error.exception.ErrorCode;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import java.util.List;
+import org.springframework.validation.BindingResult;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
-    private String code;
-    private String message;
+    private final String code;
+    private final List<ErrorMessage> errors;
 
-    public ErrorResponse(final ErrorCode code) {
-        this.code = code.getCode();
-        this.message = code.getMessage();
+    public ErrorResponse(String code,
+        List<ErrorMessage> errors) {
+        this.code = code;
+        this.errors = errors;
     }
 
-    public ErrorResponse(final ErrorCode code, String message) {
-        this.code = code.getCode();
-        this.message = message;
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code.getCode(),
+            List.of(new ErrorMessage(code.getMessage()))
+        );
     }
 
-    public String getMessage() {
-        return message;
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(
+            ErrorCode.INVALID_INPUT.getCode(),
+            ErrorField.of(bindingResult));
     }
 
     public String getCode() {
         return code;
+    }
+
+    public List<ErrorMessage> getErrors() {
+        return errors;
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.devcourse.eggmarket.global.error;
 
 import com.devcourse.eggmarket.global.error.exception.BusinessException;
 import com.devcourse.eggmarket.global.error.exception.ErrorCode;
-import javax.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -18,22 +17,25 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BindException.class)
     protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
         log.warn("{}", e.getMessage());
-        final ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_INPUT, e.getMessage());
+
+        final ErrorResponse response = ErrorResponse.of(e);
         return ResponseEntity.badRequest().body(response);
     }
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.error("{}", e.getMessage());
+
         final ErrorCode errorCode = e.getErrorCode();
-        final ErrorResponse response = new ErrorResponse(errorCode);
+        final ErrorResponse response = ErrorResponse.of(errorCode);
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("{}", e.getMessage());
-        final ErrorResponse response = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.internalServerError().body(response);
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/eggmarket/global/error/exception/ErrorCode.java
@@ -17,8 +17,9 @@ public enum ErrorCode {
 
     // comment error
     SOLD_OUT_POST_NOT_ALLOWED_COMMENT_ERROR("C01", "판매 완료된 글에는 댓글을 작성할 수 없습니다",
-        HttpStatus.FORBIDDEN),
-    NOT_ALLOWED_BUYER("C02", "해당 판매글에 대한 구매자로 등록할 수 없습니다", HttpStatus.BAD_REQUEST);
+        HttpStatus.BAD_REQUEST),
+    NOT_ALLOWED_BUYER("C02", "해당 판매글에 대한 구매자로 등록할 수 없습니다", HttpStatus.BAD_REQUEST),
+    NOT_ALLOWED_USER("C03", "해당 댓글에 대한 권한이 없는 사용자입니다", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
@@ -48,20 +48,46 @@ class CommentRepositoryTest {
             .category(Category.BEAUTY)
             .build();
 
+        comment1 = new Comment(post, postWriter, "I'm writing comment to my own post!");
+        comment2 = new Comment(post, postWriter, "I'm writing comment to my own post!");
+
         userRepository.save(postWriter);
         postRepository.save(post);
-        commentRepository.save(
-            new Comment(post, postWriter, "I'm writing comment to my own post!"));
-        commentRepository.save(
-            new Comment(post, postWriter, "I'm writing comment to my own post!"));
+
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
     }
 
     @Test
     @DisplayName("해당 판매글의 댓글들을 가져올 수 있다")
-    public void findAllByPost() {
+    void findAllByPost() {
         List<Comment> allComments = commentRepository.findAllByPost(post);
 
         Assertions.assertThat(allComments.size())
             .isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("포스트를 삭제하면 해당 포스트에 대한 모든 댓글들을 삭제한다")
+    void cascadeDeleteByPost() {
+        postRepository.delete(post);
+
+        List<Comment> allComments = commentRepository.findAllByPost(post);
+
+        Assertions.assertThat(allComments.size())
+            .isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("commentId 의 식별자를 가지면서 해당 포스트에 속한 단일 댓글이 존재할 경우 그 커멘트를 찾아온다")
+    void findByIdAndPostId() {
+        Comment foundComment =
+            commentRepository.findByIdAndPostId(
+                comment1.getId(),
+                comment1.getPost().getId()).get();
+
+        Assertions.assertThat(foundComment)
+            .usingRecursiveComparison()
+            .isEqualTo(comment1);
     }
 }


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 예외 발생 시, 기존에는 아래와 같은 모습
```json
{
    "code": "G03",
    "message": "서버 에러 입니다"
}
```
```java
{
    "code": "G01",
    "message": "org.springframework.validation.BeanPropertyBindingResult: 2 errors\nField error in object 'save' on field 'category': rejected value [BEAUT]; codes [ValueOfEnum.save.category,ValueOfEnum.category,ValueOfEnum.java.lang.String,ValueOfEnum]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [save.category,category]; arguments []; default message [category],class com.devcourse.eggmarket.domain.post.model.Category]; default message [잘못 된 카테고리 입니다]\nField error in object 'save' on field 'price': rejected value [-1]; codes [PositiveOrZero.save.price,PositiveOrZero.price,PositiveOrZero.int,PositiveOrZero]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [save.price,price]; arguments []; default message [price]]; default message [가격은 음수일 수 없습니다]"
}
```
- 즉, 바인딩 에러에 대한 적절한 메시지를 출력하고 있지 못한 상황이었음
- 바인딩 에러만을 위한 별개의 객체를 정의하지는 말자는 의견이 나왔었음
- 따라서 공통적인 에러 응답 객체를 사용하여, 바인딩 에러 상황에 대해서도 코드에 설정한 디폴트 메시지를 깔끔하게 응답객체에게 전달하고자 하였음

## 변경 후
비즈니스 예외에 대해서는 아래와 같은 모습
```json
{
    "code": "C03",
    "errors": [
        {
            "message": "해당 댓글에 대한 권한이 없는 사용자입니다"
        }
    ]
}
```

G01 에러들에 대해서는 → 각 필드들에 대한 에러들을 모두 출력 가능

```json
{
    "code": "G01",
    "errors": [
        {
            "message": "가격은 음수일 수 없습니다",
            "field": "price",
            "value": "-1"
        },
        {
            "message": "잘못 된 카테고리 입니다",
            "field": "category",
            "value": "BEAUT"
        }
    ]
}
```

## 브랜치를 잘못 나누었슴다..
현재 PR 에 올라와있는, 댓글 수정과 관련된 커밋이 함께 포함되어버렸습니다 ㅠㅠ.. 
댓글 수정 관련 코드 브랜치에서 새로운 브랜치를 만들었던 것 같습니당.. 혹시 이로인한 문제가 생길까요?? 

## 작업으로 인해 해결된 이슈 번호
- EM-72