### PR TITLE
✨ feat : 댓글 삭제 기능 구현 및 서비스 테스트 구현

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
@@ -7,14 +7,17 @@ import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
+@RequestMapping("/posts/{postId}")
 public class CommentController {
 
     private final CommentService commentService;
@@ -24,7 +27,7 @@ public class CommentController {
         this.commentService = commentService;
     }
 
-    @PostMapping("/posts/{postId}/comments")
+    @PostMapping("/comments")
     public ResponseEntity<SuccessResponse<Long>> save(@PathVariable Long postId,
         @RequestBody @Valid CommentRequest.Save createRequest, Authentication authentication) {
 
@@ -39,7 +42,7 @@ public class CommentController {
             .body(new SuccessResponse<>(commentId));
     }
 
-    @PutMapping("/posts/{postId}/comments/{commentId}")
+    @PutMapping("/comments/{commentId}")
     public ResponseEntity<SuccessResponse<Long>> update(@PathVariable Long postId,
         @PathVariable Long commentId, @RequestBody @Valid CommentRequest.Update updateRequest,
         Authentication authentication) {
@@ -49,5 +52,14 @@ public class CommentController {
 
         return ResponseEntity.ok(
             new SuccessResponse<>(updatedCommentId));
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<SuccessResponse<Void>> delete(@PathVariable Long postId,
+        @PathVariable Long commentId, Authentication authentication) {
+
+        commentService.delete(authentication.getName(), postId, commentId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/api/CommentController.java
@@ -55,7 +55,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<SuccessResponse<Void>> delete(@PathVariable Long postId,
+    public ResponseEntity<Void> delete(@PathVariable Long postId,
         @PathVariable Long commentId, Authentication authentication) {
 
         commentService.delete(authentication.getName(), postId, commentId);

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/service/DefaultCommentService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/service/DefaultCommentService.java
@@ -78,7 +78,14 @@ public class DefaultCommentService implements CommentService {
     @Override
     @Transactional
     public void delete(String userName, Long postId, Long commentId) {
-        // TODO
+        User loginUser = getLoginUser(userName);
+        Post post = getExistingPost(postId);
+
+        Comment comment = getExistingComment(commentId, post);
+
+        checkCommentWriter(loginUser, comment);
+
+        commentRepository.delete(comment);
     }
 
     private Post getExistingPost(Long postId) {
@@ -100,7 +107,8 @@ public class DefaultCommentService implements CommentService {
 
     private void checkNotSoldOutPost(Post post) {
         if (!post.isAbleToDeal()) {
-            throw new CommentNotAllowedPostException(ErrorCode.SOLD_OUT_POST_NOT_ALLOWED_COMMENT_ERROR);
+            throw new CommentNotAllowedPostException(
+                ErrorCode.SOLD_OUT_POST_NOT_ALLOWED_COMMENT_ERROR);
         }
     }
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 댓글 삭제 기능 구현 ( 컨트롤러, 서비스)
- 댓글 삭제 기능 서비스 테스트 (기능 테스트) 추가
- 댓글 컨트롤러 클래스레벨에 RequestMapping("posts/{postId}") 추가


## 작업으로 인해 해결된 이슈 번호
- EM-28