### PR TITLE
🔧 config : 배포시 유저 권한 문제로 인한 로그백 에러 발생에 대한 처리

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,12 +28,9 @@ jobs:
       - name: Create Logging File Directory
         run: sudo mkdir /var/log/egg-market
 
-      - name: github actions runner name check
-        run: whoami
-
       # logback 용 로깅 파일 디렉토리 일반 유저 권한 부여
       - name: Logging Directory Permission Configure
-        run: sudo chown ubuntu:ubuntu /var/log/egg-market
+        run: sudo chown runner:runner /var/log/egg-market
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,6 +23,15 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+
+      # logback 용 로깅 파일 디렉토리 생성
+      - name: Create Logging File Directory
+        run: sudo mkdir /var/log/egg-market
+
+      # logback 용 로깅 파일 디렉토리 일반 유저 권한 부여
+      - name: Logging Directory Permission Configure
+        run: sudo chown ubuntu:ubuntu /var/log/egg-market
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Create Logging File Directory
         run: sudo mkdir /var/log/egg-market
 
+      - name: github actions runner name check
+        run: whoami
+
       # logback 용 로깅 파일 디렉토리 일반 유저 권한 부여
       - name: Logging Directory Permission Configure
         run: sudo chown ubuntu:ubuntu /var/log/egg-market

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -12,6 +12,8 @@
   <property name="INFO_FILE_LOG_PATTERN"
     value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
+  <property name="LOG_PATH" value="/var/log/egg-market"/>
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>${CONSOLE_LOG_PATTERN}</pattern>
@@ -25,7 +27,7 @@
       <onMismatch>DENY</onMismatch>
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>logs/error-%d{yyyy-MM}.log</fileNamePattern>
+      <fileNamePattern>${LOG_PATH}/error-%d{yyyy-MM}.log</fileNamePattern>
     </rollingPolicy>
     <encoder>
       <pattern>${ERROR_FILE_LOG_PATTERN}</pattern>
@@ -34,7 +36,7 @@
 
   <appender name="INFO_ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>logs/%d{yyyyMMdd}.log</fileNamePattern>
+      <fileNamePattern>${LOG_PATH}/%d{yyyyMMdd}.log</fileNamePattern>
     </rollingPolicy>
     <encoder>
       <pattern>${INFO_FILE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 로그 생성시 생성하는 폴더의 권한이 낮아 (일반유저로 `/`에 만들려고 시도) 실행 후 계속 에러 발생으로 꺼지는 현상이 발생
- `/var/log/egg-market` 이라는 폴더를 만들고 해당 폴더에 일반 유저 권한을 갖도록 수정
- logback으로 로깅한 내용은 `/var/log/egg-market` 으로 저장하도록 수정

## 이슈 번호
- EM-50