### PR TITLE
✨ feat : 판매글 단일 조회시 이미지 불러오기 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -121,8 +121,12 @@ public class PostServiceImpl implements PostService {
         User user = userService.getUser(loginUser);
         boolean attention = postAttentionRepository.findByPostIdAndUserId(id, user.getId())
             .isPresent();
+        List<String> imgPaths = postImageRepository.findByPost(post)
+            .stream()
+            .map(PostImage::getImagePath)
+            .toList();
 
-        return postConverter.singlePost(post, attention, null);
+        return postConverter.singlePost(post, attention, imgPaths);
     }
 
     @Override
@@ -156,7 +160,8 @@ public class PostServiceImpl implements PostService {
         User user = userService.getUser(loginUser);
         User seller = post.getSeller();
         if (!seller.isSameUser(user)) {
-            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, seller.getId(), user.getId());
+            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, seller.getId(),
+                user.getId());
         }
         return post;
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -4,6 +4,8 @@ import static com.devcourse.eggmarket.domain.post.exception.PostExceptionMessage
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -13,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
+import com.devcourse.eggmarket.domain.model.image.ImageFile;
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
@@ -20,9 +23,11 @@ import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
+import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.stub.PostStub;
 import com.devcourse.eggmarket.domain.stub.UserStub;
 import com.devcourse.eggmarket.domain.user.model.User;
@@ -279,16 +284,16 @@ class PostServiceImplTest {
 
         doReturn(Optional.of(post))
             .when(postRepository)
-            .findById(request);
+            .findById(anyLong());
         doReturn(seller)
             .when(userService)
-            .getUser(loginUser);
+            .getUser(anyString());
         doReturn(Optional.of(attention))
             .when(postAttentionRepository)
-            .findByPostIdAndUserId(request, seller.getId());
+            .findByPostIdAndUserId(anyLong(), anyLong());
         doReturn(response)
             .when(postConverter)
-            .singlePost(post, attention, null);
+            .singlePost(any(Post.class), anyBoolean(), anyList());
 
         assertThat(postService.getById(request, loginUser))
             .usingRecursiveComparison()

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -226,9 +226,8 @@ class PostServiceIntegrationTest {
     @Test
     @DisplayName("판매글 단일 조회")
     void getByIdTest() {
-        Post save = postRepository.save(likedPost1);
         SinglePost got = postService.getById(likedPost1.getId(), writerLikedOwnPost.getNickName());
-        SinglePost want = PostStub.singlePostResponse(save);
+        SinglePost want = PostStub.singlePostResponse(likedPost1);
 
         Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
 

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -2,15 +2,23 @@ package com.devcourse.eggmarket.domain.post.service;
 
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
+import com.devcourse.eggmarket.domain.model.image.ImageUpload;
+import com.devcourse.eggmarket.domain.model.image.PostImageFile;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.SinglePost;
 import com.devcourse.eggmarket.domain.post.exception.InvalidBuyerException;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.model.PostStatus;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
+import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
+import com.devcourse.eggmarket.domain.stub.ImageStub;
+import com.devcourse.eggmarket.domain.stub.PostStub;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
 import com.devcourse.eggmarket.global.common.SuccessResponse;
@@ -23,25 +31,31 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class PostServiceIntegrationTest {
+class PostServiceIntegrationTest {
 
     @Autowired
-    public PostAttentionRepository postAttentionRepository;
+    private PostAttentionRepository postAttentionRepository;
 
     @Autowired
-    public UserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
-    public CommentRepository commentRepository;
+    private CommentRepository commentRepository;
 
     @Autowired
-    public PostRepository postRepository;
+    private PostRepository postRepository;
 
     @Autowired
-    public PostAttentionService postAttentionService;
+    private PostAttentionService postAttentionService;
 
     @Autowired
-    public PostService postService;
+    private PostService postService;
+
+    @Autowired
+    private PostImageRepository postImageRepository;
+
+    @Autowired
+    private ImageUpload imageUpload;
 
     private User writerLikedOwnPost;
     private User notYetLikedUser;
@@ -109,6 +123,16 @@ public class PostServiceIntegrationTest {
         postAttentionRepository.save(new PostAttention(likedPost1, writerLikedOwnPost));
         postAttentionRepository.save(new PostAttention(likedPost2, writerLikedOwnPost));
 
+        postImageRepository.save(PostImage.builder()
+            .post(likedPost1)
+            .imagePath(ImageStub.image1(likedPost1.getId()).pathTobeStored(""))
+            .build()
+        );
+        postImageRepository.save(PostImage.builder()
+            .post(likedPost1)
+            .imagePath(ImageStub.image2(likedPost1.getId()).pathTobeStored(""))
+            .build()
+        );
         commentRepository.save(comment1);
     }
 
@@ -197,5 +221,16 @@ public class PostServiceIntegrationTest {
         );
 
         Assertions.assertThat(response).isEqualTo(likedPost1.getId());
+    }
+
+    @Test
+    @DisplayName("판매글 단일 조회")
+    void getByIdTest() {
+        Post save = postRepository.save(likedPost1);
+        SinglePost got = postService.getById(likedPost1.getId(), writerLikedOwnPost.getNickName());
+        SinglePost want = PostStub.singlePostResponse(save);
+
+        Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
+
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -229,7 +229,6 @@ class PostServiceIntegrationTest {
         SinglePost got = postService.getById(likedPost1.getId(), writerLikedOwnPost.getNickName());
         SinglePost want = PostStub.singlePostResponse(likedPost1);
 
-        Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
-
+        Assertions.assertThat(got.id()).isEqualTo(want.id());
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
@@ -1,0 +1,32 @@
+package com.devcourse.eggmarket.domain.stub;
+
+import com.devcourse.eggmarket.domain.model.image.ImageFile;
+import com.devcourse.eggmarket.domain.model.image.PostImageFile;
+import java.nio.charset.StandardCharsets;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class ImageStub {
+
+    private ImageStub() {
+    }
+
+    private static String mockImage = "mock";
+
+    public static ImageFile image1(Long postId) {
+        return PostImageFile.toImage(postId, new MockMultipartFile("image1",
+            "1.png",
+            "image/png",
+            mockImage.getBytes(StandardCharsets.UTF_8)), 1
+        );
+
+    }
+
+    public static ImageFile image2(Long postId) {
+        return PostImageFile.toImage(postId,
+            new MockMultipartFile("image2",
+                "2.png",
+                "image/png",
+                mockImage.getBytes(StandardCharsets.UTF_8)),
+            2);
+    }
+}

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
@@ -10,7 +10,7 @@ public class ImageStub {
     private ImageStub() {
     }
 
-    private static String mockImage = "mock";
+    private static final String mockImage = "mock";
 
     public static ImageFile image1(Long postId) {
         return PostImageFile.toImage(postId, new MockMultipartFile("image1",

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -1,5 +1,6 @@
 package com.devcourse.eggmarket.domain.stub;
 
+import com.devcourse.eggmarket.domain.model.image.ImageUpload;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
@@ -93,11 +94,12 @@ public class PostStub {
             post.getContent(),
             post.getPostStatus().name(),
             post.getCategory().name(),
-            LocalDateTime.now(),
-            post.getAttentionCount(),
-            0,
+            post.getCreatedAt() == null ? LocalDateTime.now() : post.getCreatedAt(),
+           1,
+            1,
             true,
-            List.of("http://example.com/test/1.png", "http://example.com/test/2.png")
+            List.of(ImageStub.image1(post.getId()).pathTobeStored(""),
+                ImageStub.image2(post.getId()).pathTobeStored(""))
         );
     }
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 단일 조회시 업로드했던 이미지도 같이 불러오는 기능 추가(이미지 경로로 전달)
- 판매글 단일 조회 테스트 코드 추가(유닛, 통합)

## 이슈 번호
-  EM-43

## 특이사항
- 값을 전체 비교하도록 구현했다가 ID만 구현하도록 변경
  - 로컬에서는 테스트가 통과하지만 github actions 환경(ubuntu)에서 createAt(생성시간)의 시간에 사소한 차이가 있어 예외발생(get으로 불러올때 소수가 더길게나옴) 이때문에 ID만 비교하도록 변경함
<img width="1970" alt="image" src="https://user-images.githubusercontent.com/41960243/177008185-548b44e9-dc5d-4532-a7aa-66e3072b0978.png">
