### PR TITLE
🐛 fix : 프로필 이미지 업로드 경로 생성로직 수정 및 테스트코드 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
@@ -2,7 +2,6 @@ package com.devcourse.eggmarket.domain.model.image;
 
 import com.devcourse.eggmarket.domain.model.image.exception.InvalidFileException;
 import java.io.IOException;
-import java.io.InputStream;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,24 +12,17 @@ public class PostImageFile implements ImageFile {
     private final ImageType type;
     private final byte[] bytes;
     private final String fileName;
-    private final String extension;
     private final int order; // 이미지 순서
     private final long id; // 판매글 id
 
-    private PostImageFile(ImageType type, byte[] bytes, String extension, int order,
+    private PostImageFile(ImageType type, byte[] bytes, int order,
         String fileName,
         long id) {
         this.type = type;
         this.bytes = bytes;
-        this.extension = extension;
         this.fileName = fileName;
         this.order = order;
         this.id = id;
-    }
-
-    private PostImageFile(ImageType type, byte[] bytes, int order, String fileName,
-        long id) {
-        this(type, bytes, FilenameUtils.getExtension(fileName), order, fileName, id);
     }
 
     public static PostImageFile toImage(long postId, MultipartFile file, int img_order) {
@@ -38,8 +30,11 @@ public class PostImageFile implements ImageFile {
             throw new InvalidFileException("유효한 이미지 첨부가 아닙니다"); // 참고로 이미지 크기 오류는 따로 존재합니다
         }
 
-        try (InputStream inputStream = file.getInputStream()) {
-            return new PostImageFile(ImageType.POST, inputStream.readAllBytes(), img_order,
+        try {
+            return new PostImageFile(
+                ImageType.POST,
+                file.getBytes(),
+                img_order,
                 file.getOriginalFilename(),
                 postId);
         } catch (IOException e) {
@@ -68,7 +63,10 @@ public class PostImageFile implements ImageFile {
         return FilenameUtils.concat(basePath, storedName);
     }
 
-    private String extensionAppendedPath(String fileNameWithoutExtension) {
-        return String.join(EXTENSION_SEPARATOR, fileNameWithoutExtension, this.extension);
+    private String extensionAppendedPath(String filenameToBeStored) {
+        return String.join(
+            EXTENSION_SEPARATOR,
+            filenameToBeStored,
+            FilenameUtils.getExtension(this.fileName));
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ProfileImageFile.java
@@ -2,12 +2,15 @@ package com.devcourse.eggmarket.domain.model.image;
 
 import com.devcourse.eggmarket.domain.model.image.exception.InvalidFileException;
 import java.io.IOException;
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ProfileImageFile implements ImageFile {
 
+    private static final String EXTENSION_DELIMITER = ".";
+
     private final ImageType type;
-	private final byte[] bytes;
+    private final byte[] bytes;
     private final Long userId;
     private final String fileName;
 
@@ -16,7 +19,7 @@ public class ProfileImageFile implements ImageFile {
         this.type = type;
         this.bytes = bytes;
         this.userId = userId;
-        this.fileName = userId.toString() + "." + file.getContentType().split("/")[1];
+        this.fileName = file.getOriginalFilename();
     }
 
     public static ProfileImageFile toImage(Long userId, MultipartFile file) {
@@ -25,10 +28,9 @@ public class ProfileImageFile implements ImageFile {
         }
 
         try {
-			byte[] bytes = file.getBytes();
-            return new ProfileImageFile(ImageType.PROFILE, bytes, userId, file);
+            return new ProfileImageFile(ImageType.PROFILE, file.getBytes(), userId, file);
         } catch (IOException e) {
-			throw new InvalidFileException("업로드된 Profile 파일을 읽어오는데 실패하였습니다");
+            throw new InvalidFileException("업로드된 Profile 파일을 읽어오는데 실패하였습니다");
         }
     }
 
@@ -39,7 +41,12 @@ public class ProfileImageFile implements ImageFile {
 
     @Override
     public String pathTobeStored(String basePath) {
-        return basePath + "\\" + fileName;
+        String storedName = String.join(
+            EXTENSION_DELIMITER,
+            Long.toString(userId),
+            FilenameUtils.getExtension(this.fileName));
+
+        return FilenameUtils.concat(basePath, storedName);
     }
 
     @Override

--- a/src/test/java/com/devcourse/eggmarket/domain/model/ProfileImageFileTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/model/ProfileImageFileTest.java
@@ -1,0 +1,28 @@
+package com.devcourse.eggmarket.domain.model;
+
+import com.devcourse.eggmarket.domain.model.image.ProfileImageFile;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ProfileImageFileTest {
+
+    @Test
+    @DisplayName("멀티파트와 유저아이디가 주어지면 프로필이미지 생성 경로를 생성할 수 있다")
+    public void createFilePath() {
+        MultipartFile multipartFile = new MockMultipartFile(
+            "img.png",
+            "src/test/java/com/devcourse/eggmarket/domain/model/image/data/img.png",
+            "image/png",
+            new byte[]{1});
+        String basePath = "profile";
+
+        ProfileImageFile profileImageFile = ProfileImageFile.toImage(1L, multipartFile);
+
+        Assertions.assertThat(
+            profileImageFile.pathTobeStored(basePath)
+        ).isEqualTo("profile/1.png");
+    }
+}


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 기존에 하드코딩된 파일 세퍼레이터로 인해 플랫폼이 달라지면 유효한 이미지 생성경로가 생성되지 않는 문제가 존재하여 이를 해결하고자 하였습니다
- PostImageFile 클래스에서 처럼 apache commons 라이브러리를 사용하여 플랫폼 의존적이지 않은 파일업로드 경로를 생성하도록 하였습니다

## 작업으로 인해 해결된 이슈 번호
- EM-75