### PR TITLE
✨  feat : 스키마 DDL 스크립트 추가 및 yaml 설정 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>

--- a/src/main/java/com/devcourse/eggmarket/domain/comment/model/Comment.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/comment/model/Comment.java
@@ -7,6 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -21,7 +22,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class Comment extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/devcourse/eggmarket/domain/evaluation/model/Evaluation.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/evaluation/model/Evaluation.java
@@ -18,7 +18,7 @@ public class Evaluation extends BaseEntity {
 
     @Id
     @Column(name = "id", nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "reviewer_id")

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
@@ -13,6 +13,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -29,7 +30,7 @@ public class Post extends BaseEntity {
 
     @Id
     @Column(name = "id")
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "price")

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostAttention.java
@@ -5,6 +5,7 @@ import com.devcourse.eggmarket.domain.user.model.User;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,7 +20,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class PostAttention extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
@@ -4,6 +4,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -18,7 +19,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class PostImage {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/PostImage.java
@@ -1,5 +1,6 @@
 package com.devcourse.eggmarket.domain.post.model;
 
+import com.devcourse.eggmarket.domain.model.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,7 +17,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostImage {
+public class PostImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/devcourse/eggmarket/domain/user/model/User.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/model/User.java
@@ -30,7 +30,7 @@ public class User extends BaseEntity {
     @Column(name = "phone_number", nullable = false, unique = true, length = 15)
     private String phoneNumber;
 
-    @Column(name = "nick_name", nullable = false, unique = true, length = 12)
+    @Column(name = "nickname", nullable = false, unique = true, length = 12)
     private String nickName;
 
     @Column(name = "password", nullable = false, length = 64)

--- a/src/main/java/com/devcourse/eggmarket/domain/user/model/User.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/model/User.java
@@ -24,7 +24,7 @@ public class User extends BaseEntity {
 
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "phone_number", nullable = false, unique = true, length = 15)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -13,8 +13,6 @@ spring:
     password:
   jpa:
     open-in-view: false
-    hibernate:
-      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  sql:
+    init:
+      mode: always
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost/egg_market
+    username: yeon
+    password: root1234
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        query.in_clause_parameter_padding: true
+image:
+  base: ${user.dir}
+  type:
+    post: post
+    profile: profile

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,120 @@
+DROP TABLE IF EXISTS post_attention;
+DROP TABLE IF EXISTS comment;
+DROP TABLE IF EXISTS evaluation;
+DROP TABLE IF EXISTS post_image;
+DROP TABLE IF EXISTS post;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE USERS
+(
+    id 						BIGINT AUTO_INCREMENT,
+    phone_number 			VARCHAR(15)	NOT NULL UNIQUE,
+    nickname				VARCHAR(64) NOT NULL UNIQUE,
+    manner_temperature 		FLOAT NOT NULL,
+    image_path				VARCHAR(100),
+    role					VARCHAR(20) NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
+
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE Post
+(
+    id						BIGINT AUTO_INCREMENT,
+    seller_id				BIGINT,
+    buyer_id				BIGINT,
+    price					INT NOT NULL,
+    title					VARCHAR(255) NOT NULL,
+    content					VARCHAR(1024) NOT NULL,
+    post_status				VARCHAR(20) NOT NULL,
+    category				VARCHAR(20) NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
+
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE post_attention
+(
+    id						BIGINT AUTO_INCREMENT,
+    post_id					BIGINT NOT NULL,
+    user_id					BIGINT NOT NULL,
+
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE post_image
+(
+    id						BIGINT AUTO_INCREMENT,
+    post_id					BIGINT NOT NULL,
+    image_path				VARCHAR(100) NOT NULL,
+
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE evaluation
+(
+    id						BIGINT AUTO_INCREMENT,
+    reviewer_id				BIGINT,
+    reviewee_id				BIGINT NOT NULL, -- DELETE ON CASCADE 를 해야할지?
+    post_id					BIGINT,
+    score					TINYINT NOT NULL,
+    content					VARCHAR(500) NOT NULL,
+
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE comment
+(
+    id						BIGINT AUTO_INCREMENT,
+    post_id					BIGINT NOT NULL,
+    user_id					BIGINT NOT NULL,
+    content					VARCHAR(500) NOT NULL,
+
+    PRIMARY KEY(id)
+);
+
+ALTER TABLE comment
+    ADD CONSTRAINT comment_fk_post
+        FOREIGN KEY (post_id) REFERENCES post(id) ON DELETE CASCADE;
+
+ALTER TABLE comment
+    ADD CONSTRAINT comment_fk_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE evaluation
+    ADD CONSTRAINT evaluation_fk_reviewer_user
+        FOREIGN KEY (reviewer_id) REFERENCES users(id);
+
+ALTER TABLE evaluation
+    ADD CONSTRAINT evaluation_fk_post
+        FOREIGN KEY (post_id) REFERENCES users(id);
+
+ALTER TABLE evaluation
+    ADD CONSTRAINT evaluation_fk_reviewee_user
+        FOREIGN KEY (reviewee_id) REFERENCES users(id) ON DELETE CASCADE;
+
+-- ALTER TABLE users
+-- 	ADD CONSTRAINT phone_unique UNIQUE (phone_number);
+--
+-- ALTER TABLE users
+-- 	ADD CONSTRAINT name_unique UNIQUE (nickname);
+
+ALTER TABLE post
+    ADD CONSTRAINT post_fk_user
+        FOREIGN KEY (seller_id) REFERENCES users(id);
+
+ALTER TABLE post_image
+    ADD CONSTRAINT post_image_fk_post
+        FOREIGN KEY (post_id) REFERENCES post(id) ON DELETE CASCADE;
+
+ALTER TABLE post_attention
+    ADD CONSTRAINT post_attention_fk_post
+        FOREIGN KEY (post_id) REFERENCES post(id) ON DELETE CASCADE;
+
+ALTER TABLE post_attention
+    ADD CONSTRAINT post_attention_fk_users
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,7 +9,8 @@ CREATE TABLE USERS
 (
     id 						BIGINT AUTO_INCREMENT,
     phone_number 			VARCHAR(15)	NOT NULL UNIQUE,
-    nickname				VARCHAR(64) NOT NULL UNIQUE,
+    nickname				VARCHAR(12) NOT NULL UNIQUE,
+    password                VARCHAR(64) NOT NULL,
     manner_temperature 		FLOAT NOT NULL,
     image_path				VARCHAR(100),
     role					VARCHAR(20) NOT NULL,
@@ -40,6 +41,8 @@ CREATE TABLE post_attention
     id						BIGINT AUTO_INCREMENT,
     post_id					BIGINT NOT NULL,
     user_id					BIGINT NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
 
     PRIMARY KEY(id)
 );
@@ -49,6 +52,8 @@ CREATE TABLE post_image
     id						BIGINT AUTO_INCREMENT,
     post_id					BIGINT NOT NULL,
     image_path				VARCHAR(100) NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
 
     PRIMARY KEY(id)
 );
@@ -61,6 +66,8 @@ CREATE TABLE evaluation
     post_id					BIGINT,
     score					TINYINT NOT NULL,
     content					VARCHAR(500) NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
 
     PRIMARY KEY(id)
 );
@@ -71,6 +78,8 @@ CREATE TABLE comment
     post_id					BIGINT NOT NULL,
     user_id					BIGINT NOT NULL,
     content					VARCHAR(500) NOT NULL,
+    created_at				DATE NOT NULL,
+    updated_at				DATE,
 
     PRIMARY KEY(id)
 );

--- a/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
@@ -16,10 +16,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@EnableJpaAuditing
 class CommentRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
@@ -16,6 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 class CommentRepositoryTest {
@@ -79,6 +81,7 @@ class CommentRepositoryTest {
 
     @Test
     @DisplayName("포스트를 삭제하면 해당 포스트에 대한 모든 댓글들을 삭제한다")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void cascadeDeleteByPost() {
         postRepository.delete(post);
 


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 기본키 생성전략을 IDENTITY 로 변경
- 스키마 스크립트를 사용하기 위해 yaml 의 hibernate 의 ddl-auto 를 제거 

fk 들에 대해 이름을 직접 명시해두어서 아래와 같습니다
![image](https://user-images.githubusercontent.com/53856184/177067518-e61f9ad5-e32c-41c6-8679-1d6a1811e6b0.png)

## 고민되는 사항
- 프로필 별로 설정을 다르게 할 것인지에 대해 고민됩니다. local 만을 사용해오던 상황이라, 기존의 local 에 설정을 그대로 변경하였는데, 이에 대한 고민이 존재합니다 
- flyway 잔재가 남아있슴다

## 작업으로 인해 해결된 이슈 번호
- EM-46