### PR TITLE
♻️  refactor : 관심목록 받아올 때 이미지 경로도 함께 가져오기 리팩토링

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -55,7 +55,8 @@ public class PostController {
     }
 
     @PatchMapping("/{id}")
-    ResponseEntity<SuccessResponse<Long>> updatePost(@RequestBody @Valid PostRequest.UpdatePost request,
+    ResponseEntity<SuccessResponse<Long>> updatePost(
+        @RequestBody @Valid PostRequest.UpdatePost request,
         Authentication authentication,
         @PathVariable Long id) {
         Long response = postService.updatePost(id, request, authentication.getName());
@@ -93,7 +94,7 @@ public class PostController {
     ResponseEntity<SuccessResponse<Posts>> allAttention(Authentication authentication) {
         return ResponseEntity.ok(
             new SuccessResponse<>(
-                postAttentionService.getAllLikedBy(authentication.getName())
+                postService.getAllLikedBy(authentication.getName())
             )
         );
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -12,6 +12,7 @@ import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
@@ -40,7 +41,7 @@ public class PostController {
         this.postAttentionService = postAttentionService;
     }
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<SuccessResponse<Long>> write(@Valid PostRequest.Save request,
         Authentication authentication) {
         Long response = postService.save(request, authentication.getName());

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepository.java
@@ -3,11 +3,10 @@ package com.devcourse.eggmarket.domain.post.repository;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostImage;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
-    List<PostImage> findByPost(Post post);
+    List<PostImage> findAllByPost(Post post);
 
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
@@ -1,6 +1,5 @@
 package com.devcourse.eggmarket.domain.post.repository;
 
-import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import java.util.List;

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
@@ -1,18 +1,12 @@
 package com.devcourse.eggmarket.domain.post.service;
 
-import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
-import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
-import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
-import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -21,20 +15,14 @@ public class DefaultPostAttentionService implements PostAttentionService {
 
     private final PostAttentionRepository postAttentionRepository;
     private final PostRepository postRepository;
-    private final PostImageRepository postImageRepository;
-    private final PostConverter postConverter;
     private final UserService userService;
 
     public DefaultPostAttentionService(
         PostAttentionRepository postAttentionRepository,
         PostRepository postRepository,
-        PostConverter postConverter,
-        PostImageRepository postImageRepository,
         UserService userService) {
         this.postAttentionRepository = postAttentionRepository;
         this.postRepository = postRepository;
-        this.postConverter = postConverter;
-        this.postImageRepository = postImageRepository;
         this.userService = userService;
     }
 
@@ -56,28 +44,7 @@ public class DefaultPostAttentionService implements PostAttentionService {
         );
     }
 
-    @Override
-    public Posts getAllLikedBy(String userName) {
-        return new Posts(
-            postRepository.findAllLikedBy(getUserId(userName)).stream()
-                .map(this::thumbnailAddedPostResponse)
-                .collect(Collectors.toList()));
-    }
-
-    private PostsElement thumbnailAddedPostResponse(Post post) {
-        String path = postImageRepository.findAllByPost(post).stream()
-            .findFirst()
-            .map(PostImage::getImagePath)
-            .orElse(null);
-
-        return postConverter.postsElement(post, path);
-    }
-
     private User getUser(String nickName) {
         return userService.getUser(nickName);
-    }
-
-    private Long getUserId(String nickName) {
-        return this.getUser(nickName).getId();
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/DefaultPostAttentionService.java
@@ -3,9 +3,12 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostsElement;
 import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
+import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
+import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.service.UserService;
@@ -18,6 +21,7 @@ public class DefaultPostAttentionService implements PostAttentionService {
 
     private final PostAttentionRepository postAttentionRepository;
     private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
     private final PostConverter postConverter;
     private final UserService userService;
 
@@ -25,10 +29,12 @@ public class DefaultPostAttentionService implements PostAttentionService {
         PostAttentionRepository postAttentionRepository,
         PostRepository postRepository,
         PostConverter postConverter,
+        PostImageRepository postImageRepository,
         UserService userService) {
         this.postAttentionRepository = postAttentionRepository;
         this.postRepository = postRepository;
         this.postConverter = postConverter;
+        this.postImageRepository = postImageRepository;
         this.userService = userService;
     }
 
@@ -54,8 +60,17 @@ public class DefaultPostAttentionService implements PostAttentionService {
     public Posts getAllLikedBy(String userName) {
         return new Posts(
             postRepository.findAllLikedBy(getUserId(userName)).stream()
-                .map(post -> postConverter.postsElement(post, null)) // TODO : 한 개의 이미지 경로 가져오기
+                .map(this::thumbnailAddedPostResponse)
                 .collect(Collectors.toList()));
+    }
+
+    private PostsElement thumbnailAddedPostResponse(Post post) {
+        String path = postImageRepository.findAllByPost(post).stream()
+            .findFirst()
+            .map(PostImage::getImagePath)
+            .orElse(null);
+
+        return postConverter.postsElement(post, path);
     }
 
     private User getUser(String nickName) {

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostAttentionService.java
@@ -1,11 +1,8 @@
 package com.devcourse.eggmarket.domain.post.service;
 
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.PostAttentionCount;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 
 public interface PostAttentionService {
 
     PostAttentionCount toggleAttention(String userName, Long postId);
-
-    Posts getAllLikedBy(String userName);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -3,11 +3,9 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.Save;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.model.Category;
-import com.devcourse.eggmarket.global.common.SuccessResponse;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.Authentication;
 
 public interface PostService {
 
@@ -24,4 +22,7 @@ public interface PostService {
     PostResponse.Posts getAll(Pageable pageable);
 
     PostResponse.Posts getAllByCategory(Pageable pageable, Category category);
+
+    Posts getAllLikedBy(String userName);
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -159,9 +159,10 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, postId));
         User user = userService.getUser(loginUser);
+        User seller = post.getSeller();
 
-        if (!post.getSeller().isSameUser(user)) {
-            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, post.getSeller().getId(),
+        if (!seller.isSameUser(user)) {
+            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, seller.getId(),
                 user.getId());
         }
         return post;

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -122,7 +122,7 @@ public class PostServiceImpl implements PostService {
         User user = userService.getUser(loginUser);
         boolean attention = postAttentionRepository.findByPostIdAndUserId(id, user.getId())
             .isPresent();
-        List<String> imgPaths = postImageRepository.findByPost(post)
+        List<String> imgPaths = postImageRepository.findAllByPost(post)
             .stream()
             .map(PostImage::getImagePath)
             .toList();
@@ -159,21 +159,20 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new NotExistPostException(NOT_EXIST_POST, postId));
         User user = userService.getUser(loginUser);
-        User seller = post.getSeller();
-        if (!seller.isSameUser(user)) {
-            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, seller.getId(),
+
+        if (!post.getSeller().isSameUser(user)) {
+            throw new NotMatchedSellerException(NOT_MATCHED_SELLER_POST, post.getSeller().getId(),
                 user.getId());
         }
         return post;
     }
 
     private PostsElement postResponseAddThumbnail(Post post) {
-        String path = null;
+        String path = postImageRepository.findAllByPost(post).stream()
+            .findFirst()
+            .map(PostImage::getImagePath)
+            .orElse(null);
 
-        List<PostImage> images = postImageRepository.findByPost(post);
-        if (!images.isEmpty()) {
-            path = images.get(0).getImagePath();
-        }
         return postConverter.postsElement(post, path);
     }
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -144,6 +145,16 @@ public class PostServiceImpl implements PostService {
             .map(this::postResponseAddThumbnail)
             .getContent()
         );
+    }
+
+    @Override
+    public Posts getAllLikedBy(String userName) {
+        User loginUser = userService.getUser(userName);
+
+        return new Posts(
+            postRepository.findAllLikedBy(loginUser.getId()).stream()
+                .map(this::postResponseAddThumbnail)
+                .collect(Collectors.toList()));
     }
 
     private String uploadFile(Post post, ImageFile file) {

--- a/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.service.UserService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +28,7 @@ public class UserController {
         this.passwordEncoder = passwordEncoder;
     }
 
-    @PostMapping("/signup")
+    @PostMapping(path = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public UserResponse signUp(UserRequest.Save request) {
         return userService.save(request);
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -455,7 +455,7 @@ class PostControllerTest {
         PostResponse.Posts response = PostStub.posts();
 
         doReturn(response)
-            .when(postAttentionService)
+            .when(postService)
             .getAllLikedBy(anyString());
         ResultActions resultActions = mockMvc.perform(
             MockMvcRequestBuilders.get("/posts/attention")

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostImageRepositoryTest.java
@@ -7,7 +7,6 @@ import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +64,7 @@ class PostImageRepositoryTest {
             )).toList();
 
         // given
-        List<PostImage> foundImgPaths = postImageRepository.findByPost(post);
+        List<PostImage> foundImgPaths = postImageRepository.findAllByPost(post);
 
         // then
         Assertions.assertThat(foundImgPaths.size())

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -171,10 +171,11 @@ class PostServiceIntegrationTest {
     @Test
     @DisplayName("로그인 사용자는 자신의 관심목록을 확인한다")
     void getAllLikedPosts() {
-        Posts allLikedPosts = postAttentionService.getAllLikedBy(
+        Posts allLikedPosts = postService.getAllLikedBy(
             writerLikedOwnPost.getNickName());
 
-        Assertions.assertThat(allLikedPosts.posts().size()).isEqualTo(2);
+        Assertions.assertThat(allLikedPosts.posts().size())
+            .isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -2,10 +2,7 @@ package com.devcourse.eggmarket.domain.post.service;
 
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
-import com.devcourse.eggmarket.domain.model.image.ImageUpload;
-import com.devcourse.eggmarket.domain.model.image.PostImageFile;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
-import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.SinglePost;
 import com.devcourse.eggmarket.domain.post.exception.InvalidBuyerException;
@@ -21,7 +18,6 @@ import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.stub.PostStub;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
-import com.devcourse.eggmarket.global.common.SuccessResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,16 +42,13 @@ class PostServiceIntegrationTest {
     private PostRepository postRepository;
 
     @Autowired
+    private PostImageRepository postImageRepository;
+
+    @Autowired
     private PostAttentionService postAttentionService;
 
     @Autowired
     private PostService postService;
-
-    @Autowired
-    private PostImageRepository postImageRepository;
-
-    @Autowired
-    private ImageUpload imageUpload;
 
     private User writerLikedOwnPost;
     private User notYetLikedUser;
@@ -216,9 +209,9 @@ class PostServiceIntegrationTest {
             commentWriter.getId());
 
         Long response = postService.updatePurchaseInfo(
-                likedPost1.getId(),
-                updatePurchaseRequest,
-                likedPost1.getSeller().getNickName()
+            likedPost1.getId(),
+            updatePurchaseRequest,
+            likedPost1.getSeller().getNickName()
         );
 
         Assertions.assertThat(response).isEqualTo(likedPost1.getId());


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 관심 목록을 가져올 때, 포스트의 썸네일 이미지 경로를 가져오지 않고 있었어서 이를 추가하였습니다.
- 기존에 람다내 공유변수 변경 불가 제약으로 정의했던 Order 클래스를 제거하고 AtomicInteger 를 사용하였습니다. 
- 기존에 썸네일 추가 로직에 null 초기화 변수가 존재하여 null 초기화를 제거하기 위한 리팩토링을 하였습니다.
- multipart form 형식으로 요청을 받는 핸들러 메소드에는 명시적으로 consume 으로 해당 미디어 타입을 받는 것으로 하였습니다 

### 추가
- 관심 목록 을 가져오는 기능은 판매글 목록을 가져오는 서비스들 중 하나로 판단되어 PostService 로 책임을 변경하였습니다. 덕분에 썸네일을 추가하는 중복코드가 사라졌습니다 


## 고민 사항
- 판매글 목록을 가져오는 모든 기능에서 썸네일 이미지 추가 기능이 필요한 상황입니당. 그런데 관심목록을 가져오는 기능은 판매글 관심 서비스에 위치하다보니, 판매글 서비스에 존재하는 썸네일 추가 기능을 사용하지 못해 중복 코드가 발생합니다

## 작업으로 인해 해결된 이슈 번호
- EM-77