### PR TITLE
✨ feat : 판매글 검색 기능 추가

### DIFF
--- a/src/main/asciidoc/post-api.adoc
+++ b/src/main/asciidoc/post-api.adoc
@@ -123,3 +123,16 @@ include::{snippets}/post-get-attention/http-request.adoc[]
 .Response
 include::{snippets}/post-get-attention/http-response.adoc[]
 include::{snippets}/post-get-attention/response-fields.adoc[]
+
+== 검색
+
+=== GET /posts/search
+
+.Request
+include::{snippets}/post-search/http-request.adoc[]
+include::{snippets}/post-search/request-parameters.adoc[]
+
+
+.Response
+include::{snippets}/post-search/http-response.adoc[]
+include::{snippets}/post-search/response-fields.adoc[]

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -11,6 +11,7 @@ import com.devcourse.eggmarket.global.common.SuccessResponse;
 import com.devcourse.eggmarket.global.common.ValueOfEnum;
 import java.net.URI;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -118,4 +119,13 @@ public class PostController {
         );
     }
 
+    @GetMapping("/search")
+    ResponseEntity<SuccessResponse<PostResponse.Posts>> search(
+        @RequestParam @NotBlank(message = "검색할 내용을 입력해주세요") String word) {
+        return ResponseEntity.ok(
+            new SuccessResponse<>(
+                postService.search(word)
+            )
+        );
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/api/PostController.java
@@ -120,11 +120,11 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    ResponseEntity<SuccessResponse<PostResponse.Posts>> search(
+    ResponseEntity<SuccessResponse<PostResponse.Posts>> search(Pageable pageable,
         @RequestParam @NotBlank(message = "검색할 내용을 입력해주세요") String word) {
         return ResponseEntity.ok(
             new SuccessResponse<>(
-                postService.search(word)
+                postService.search(pageable, word)
             )
         );
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/model/Post.java
@@ -163,4 +163,5 @@ public class Post extends BaseEntity {
         this.postStatus = postStatus;
         this.buyer = buyer;
     }
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
@@ -19,5 +19,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByCategory(Pageable pageable, Category category);
 
-    List<Post> findByTitleContains(String word);
+    Page<Post> findAllByTitleContains(Pageable pageable, String word);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/repository/PostRepository.java
@@ -18,4 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllLikedBy(@Param("userId") Long userId);
 
     Page<Post> findAllByCategory(Pageable pageable, Category category);
+
+    List<Post> findByTitleContains(String word);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -25,4 +25,6 @@ public interface PostService {
 
     Posts getAllLikedBy(String userName);
 
+    PostResponse.Posts search(String word);
+
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostService.java
@@ -25,6 +25,7 @@ public interface PostService {
 
     Posts getAllLikedBy(String userName);
 
-    PostResponse.Posts search(String word);
+    PostResponse.Posts search(Pageable pageable, String word);
+
 
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -159,11 +159,10 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public Posts search(String word) {
-        return new Posts(postRepository.findByTitleContains(word)
-            .stream()
+    public Posts search(Pageable pageable, String word) {
+        return new Posts(postRepository.findAllByTitleContains(pageable, word)
             .map(this::postResponseAddThumbnail)
-            .toList()
+            .getContent()
         );
     }
 

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -157,6 +157,16 @@ public class PostServiceImpl implements PostService {
                 .collect(Collectors.toList()));
     }
 
+    @Override
+    public Posts search(String word) {
+        return new Posts(postRepository.findByTitleContains(word)
+            .stream()
+            .map(this::postResponseAddThumbnail)
+            .collect(Collectors.toList())
+        );
+    }
+
+
     private String uploadFile(Post post, ImageFile file) {
         return postImageRepository.save(
             PostImage.builder()

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -41,6 +41,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -468,6 +469,49 @@ class PostControllerTest {
             .andDo(document("post-get-attention",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("data.posts[].id").type(JsonFieldType.NUMBER)
+                        .description("판매글 ID"),
+                    fieldWithPath("data.posts[].price").type(JsonFieldType.NUMBER)
+                        .description("판매글 가격"),
+                    fieldWithPath("data.posts[].title").type(JsonFieldType.STRING)
+                        .description("제목"),
+                    fieldWithPath("data.posts[].postStatus").type(JsonFieldType.STRING)
+                        .description("판매 상태"),
+                    fieldWithPath("data.posts[].createdAt").type(JsonFieldType.STRING)
+                        .description("판매글 생성 시간"),
+                    fieldWithPath("data.posts[].attentionCount").type(JsonFieldType.NUMBER)
+                        .description("찜 개수"),
+                    fieldWithPath("data.posts[].commentCount").type(JsonFieldType.NUMBER)
+                        .description("댓글 개수"),
+                    fieldWithPath("data.posts[].imagePath").type(JsonFieldType.STRING)
+                        .description("대표 이미지")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("제목 검색 기능 테스트")
+    void searchTest() throws Exception {
+        String request = "title";
+        PostResponse.Posts response = PostStub.posts();
+
+        doReturn(response)
+            .when(postService)
+            .search(request);
+
+        ResultActions resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/posts/search")
+                .param("word", "title"));
+
+        resultActions.andExpect(status().isOk())
+            .andDo(document("post-search",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestParameters(
+                    parameterWithName("word").description("검색 문자열")
+                ),
                 responseFields(
                     fieldWithPath("data.posts[].id").type(JsonFieldType.NUMBER)
                         .description("판매글 ID"),

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -494,15 +495,18 @@ class PostControllerTest {
     @WithMockUser
     @DisplayName("제목 검색 기능 테스트")
     void searchTest() throws Exception {
-        String request = "title";
+        Pageable pageable = PageRequest.of(0, 3);
+        String word = "title";
         PostResponse.Posts response = PostStub.posts();
 
         doReturn(response)
             .when(postService)
-            .search(request);
+            .search(pageable, word);
 
         ResultActions resultActions = mockMvc.perform(
             RestDocumentationRequestBuilders.get("/posts/search")
+                .param("page", String.valueOf(pageable.getPageNumber()))
+                .param("size", String.valueOf(pageable.getPageSize()))
                 .param("word", "title"));
 
         resultActions.andExpect(status().isOk())
@@ -510,6 +514,8 @@ class PostControllerTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestParameters(
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("size").description("페이지당 개수"),
                     parameterWithName("word").description("검색 문자열")
                 ),
                 responseFields(

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
@@ -116,16 +116,4 @@ class PostRepositoryTest {
             .isEqualTo(2);
     }
 
-    @Test
-    @DisplayName("제목을 기준으로 판매글을 불러올 수 있다.")
-    void findPostByTitleLikeTest() {
-        List<Post> response = List.of(
-            notLikedPost1,
-            notLikedPost2
-        );
-
-        Assertions.assertThat(postRepository.findByTitleContains("test"))
-            .usingRecursiveComparison()
-            .isEqualTo(response);
-    }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/repository/PostRepositoryTest.java
@@ -5,6 +5,7 @@ import com.devcourse.eggmarket.domain.post.model.Post;
 import com.devcourse.eggmarket.domain.post.model.PostAttention;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class PostRepositoryTest {
+class PostRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
@@ -29,7 +30,8 @@ public class PostRepositoryTest {
     private User notWriter;
     private Post likedPost1;
     private Post likedPost2;
-    private Post notLikedPost;
+    private Post notLikedPost1;
+    private Post notLikedPost2;
 
     @BeforeEach
     void setUp() {
@@ -63,19 +65,27 @@ public class PostRepositoryTest {
             .seller(writer)
             .build();
 
-        notLikedPost = Post.builder()
+        notLikedPost1 = Post.builder()
             .price(1400)
-            .title("title11")
+            .title("test2")
             .content("content12")
             .category(Category.BEAUTY)
             .seller(writer)
             .build();
 
+        notLikedPost2 = Post.builder()
+            .price(1400)
+            .title("test1")
+            .content("content12")
+            .category(Category.BEAUTY)
+            .seller(writer)
+            .build();
         userRepository.save(writer);
         userRepository.save(notWriter);
         postRepository.save(likedPost1);
         postRepository.save(likedPost2);
-        postRepository.save(notLikedPost);
+        postRepository.save(notLikedPost1);
+        postRepository.save(notLikedPost2);
 
         postAttentionRepository.save(new PostAttention(likedPost1, notWriter));
         postAttentionRepository.save(new PostAttention(likedPost2, notWriter));
@@ -90,7 +100,7 @@ public class PostRepositoryTest {
 
     @Test
     @DisplayName("조회해 온 포스트 엔티티에 대한 관심개수를 알 수 있다")
-    public void attentionCount() {
+    void attentionCountTest() {
         Post foundPost = postRepository.findById(this.likedPost1.getId()).get();
 
         Assertions.assertThat(foundPost.getAttentionCount())
@@ -99,10 +109,23 @@ public class PostRepositoryTest {
 
     @Test
     @DisplayName("특정한 사용자가 관심목록에 추가 한 모든 게시글을 찾아올 수 있다")
-    public void test() {
+    void getAttentiontest() {
         int likedPostsCount = postRepository.findAllLikedBy(notWriter.getId()).size();
 
         Assertions.assertThat(likedPostsCount)
             .isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("제목을 기준으로 판매글을 불러올 수 있다.")
+    void findPostByTitleLikeTest() {
+        List<Post> response = List.of(
+            notLikedPost1,
+            notLikedPost2
+        );
+
+        Assertions.assertThat(postRepository.findByTitleContains("test"))
+            .usingRecursiveComparison()
+            .isEqualTo(response);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
-import com.devcourse.eggmarket.domain.model.image.ImageFile;
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
@@ -23,11 +22,9 @@ import com.devcourse.eggmarket.domain.post.exception.NotExistPostException;
 import com.devcourse.eggmarket.domain.post.exception.NotMatchedSellerException;
 import com.devcourse.eggmarket.domain.post.model.Category;
 import com.devcourse.eggmarket.domain.post.model.Post;
-import com.devcourse.eggmarket.domain.post.model.PostImage;
 import com.devcourse.eggmarket.domain.post.repository.PostAttentionRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostImageRepository;
 import com.devcourse.eggmarket.domain.post.repository.PostRepository;
-import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.stub.PostStub;
 import com.devcourse.eggmarket.domain.stub.UserStub;
 import com.devcourse.eggmarket.domain.user.model.User;
@@ -356,6 +353,21 @@ class PostServiceImplTest {
             .getAllByCategory(request, category);
 
         assertThat(postService.getAllByCategory(request, category))
+            .usingRecursiveComparison()
+            .isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("제목을 기준으로 판매글 검색하기")
+    void searchTest() {
+        String request = "title";
+        PostResponse.Posts response = PostStub.posts();
+
+        doReturn(response)
+            .when(postService)
+            .search(request);
+
+        assertThat(postService.search(request))
             .usingRecursiveComparison()
             .isEqualTo(response);
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -38,6 +38,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -360,14 +361,15 @@ class PostServiceImplTest {
     @Test
     @DisplayName("제목을 기준으로 판매글 검색하기")
     void searchTest() {
-        String request = "title";
+        Pageable pageable = PageRequest.of(0, 3);
+        String word = "title";
         PostResponse.Posts response = PostStub.posts();
 
         doReturn(response)
             .when(postService)
-            .search(request);
+            .search(pageable, word);
 
-        assertThat(postService.search(request))
+        assertThat(postService.search(pageable, word))
             .usingRecursiveComparison()
             .isEqualTo(response);
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.devcourse.eggmarket.domain.post.service;
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest.UpdatePurchaseInfo;
+import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.SinglePost;
 import com.devcourse.eggmarket.domain.post.exception.InvalidBuyerException;
@@ -56,6 +57,8 @@ class PostServiceIntegrationTest {
     private User commentWriter;
     private Post likedPost1;
     private Post likedPost2;
+    private Post notLikedPost1;
+    private Post notLikedPost2;
 
     @BeforeEach
     void setUp() {
@@ -103,6 +106,21 @@ class PostServiceIntegrationTest {
             .seller(writerLikedOwnPost)
             .build();
 
+        notLikedPost1 = Post.builder()
+            .title("test1")
+            .content("content")
+            .price(1000)
+            .category(Category.BEAUTY)
+            .seller(writerLikedOwnPost)
+            .build();
+        notLikedPost2 = Post.builder()
+            .title("test2")
+            .content("content")
+            .price(2500)
+            .category(Category.BEAUTY)
+            .seller(writerLikedOwnPost)
+            .build();
+
         Comment comment1 = new Comment(likedPost1, commentWriter, "I want to buy your stuff");
 
         userRepository.save(writerLikedOwnPost);
@@ -112,6 +130,8 @@ class PostServiceIntegrationTest {
 
         postRepository.save(likedPost1);
         postRepository.save(likedPost2);
+        postRepository.save(notLikedPost1);
+        postRepository.save(notLikedPost2);
 
         postAttentionRepository.save(new PostAttention(likedPost1, writerLikedOwnPost));
         postAttentionRepository.save(new PostAttention(likedPost2, writerLikedOwnPost));
@@ -224,5 +244,20 @@ class PostServiceIntegrationTest {
         SinglePost want = PostStub.singlePostResponse(likedPost1);
 
         Assertions.assertThat(got.id()).isEqualTo(want.id());
+    }
+
+    @Test
+    @DisplayName("판매글 제목으로 검색 테스트")
+    void searchTest() {
+        String request = "test";
+        PostResponse.Posts got = postService.search(request);
+        PostResponse.Posts want = PostStub.searchPosts(
+            notLikedPost1.getId(),
+            notLikedPost2.getId(),
+            notLikedPost1.getCreatedAt(),
+            notLikedPost2.getCreatedAt()
+        );
+
+        Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -251,13 +251,11 @@ class PostServiceIntegrationTest {
     void searchTest() {
         String request = "test";
         PostResponse.Posts got = postService.search(request);
-        PostResponse.Posts want = PostStub.searchPosts(
-            notLikedPost1.getId(),
-            notLikedPost2.getId(),
-            notLikedPost1.getCreatedAt(),
-            notLikedPost2.getCreatedAt()
-        );
+        PostResponse.Posts want = PostStub.searchPosts(notLikedPost1.getId(), notLikedPost2.getId());
 
-        Assertions.assertThat(got).usingRecursiveComparison().isEqualTo(want);
+        Assertions.assertThat(got)
+            .usingRecursiveComparison()
+            .ignoringFields("createdAt")
+            .isEqualTo(want);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @SpringBootTest
 class PostServiceIntegrationTest {
@@ -249,8 +251,9 @@ class PostServiceIntegrationTest {
     @Test
     @DisplayName("판매글 제목으로 검색 테스트")
     void searchTest() {
-        String request = "test";
-        PostResponse.Posts got = postService.search(request);
+        Pageable pageable = PageRequest.of(0, 2);
+        String word = "test";
+        PostResponse.Posts got = postService.search(pageable, word);
         PostResponse.Posts want = PostStub.searchPosts(notLikedPost1.getId(), notLikedPost2.getId());
 
         Assertions.assertThat(got)

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -255,7 +255,7 @@ class PostServiceIntegrationTest {
 
         Assertions.assertThat(got)
             .usingRecursiveComparison()
-            .ignoringFields("createdAt")
+            .ignoringFields("posts.createdAt")
             .isEqualTo(want);
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -176,6 +176,33 @@ public class PostStub {
         );
     }
 
+    public static Posts searchPosts(Long id1, Long id2, LocalDateTime time1, LocalDateTime time2) {
+        return new Posts(
+            List.of(
+                new PostsElement(
+                    id1,
+                    1000,
+                    "test1",
+                    "SALE",
+                    time1,
+                    0,
+                    0,
+                    null
+                ),
+                new PostsElement(
+                    id2,
+                    2500,
+                    "test2",
+                    "SALE",
+                    time2,
+                    0,
+                    0,
+                    null
+                )
+            )
+        );
+    }
+
     public static Stream<Arguments> invalidWriteRequest() {
         return Stream.of(
             Arguments.arguments(

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -176,7 +176,7 @@ public class PostStub {
         );
     }
 
-    public static Posts searchPosts(Long id1, Long id2, LocalDateTime time1, LocalDateTime time2) {
+    public static Posts searchPosts(Long id1, Long id2) {
         return new Posts(
             List.of(
                 new PostsElement(
@@ -184,7 +184,7 @@ public class PostStub {
                     1000,
                     "test1",
                     "SALE",
-                    time1,
+                    LocalDateTime.now(),
                     0,
                     0,
                     null
@@ -194,7 +194,7 @@ public class PostStub {
                     2500,
                     "test2",
                     "SALE",
-                    time2,
+                    LocalDateTime.now(),
                     0,
                     0,
                     null

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -1,6 +1,5 @@
 package com.devcourse.eggmarket.domain.stub;
 
-import com.devcourse.eggmarket.domain.model.image.ImageUpload;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse.Posts;
@@ -95,7 +94,7 @@ public class PostStub {
             post.getPostStatus().name(),
             post.getCategory().name(),
             post.getCreatedAt() == null ? LocalDateTime.now() : post.getCreatedAt(),
-           1,
+            1,
             1,
             true,
             List.of(ImageStub.image1(post.getId()).pathTobeStored(""),


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글을 제목을 기준으로 검색할 수 있도록 기능 추가
- `/search?word=title` 와 같은 형태로 사용
- 판매글 검색 기능 테스트 코드 추가

## 이슈 번호
- EM-25