### PR TITLE
✨  feat : 이미지 업로드 로직 변경 

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/ImageFile.java
@@ -20,7 +20,7 @@ public interface ImageFile {
 
     static boolean isNotImage(MultipartFile file) {
         if (file == null) {
-            return false;
+            return true;
         }
         return !isImageContentType(file.getContentType());
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/model/image/PostImageFile.java
@@ -27,7 +27,7 @@ public class PostImageFile implements ImageFile {
 
     public static PostImageFile toImage(long postId, MultipartFile file, int img_order) {
         if (ImageFile.isNotImage(file)) {
-            throw new InvalidFileException("유효한 이미지 첨부가 아닙니다"); // 참고로 이미지 크기 오류는 따로 존재합니다
+            throw new InvalidFileException("유효한 이미지 첨부가 아닙니다");
         }
 
         try {

--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -71,7 +71,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     @Override
     public Long save(PostRequest.Save request, String loginUser) {
-        final AtomicInteger order = new AtomicInteger(0);
+        AtomicInteger order = new AtomicInteger(0);
         User seller = userService.getUser(loginUser);
 
         Post savedPost = postRepository.save(
@@ -80,6 +80,7 @@ public class PostServiceImpl implements PostService {
 
         Optional.ofNullable(request.images())
             .orElse(Collections.emptyList()).stream()
+            .filter(file -> file.getContentType() != null)
             .map(img -> PostImageFile.toImage(savedPost.getId(), img, order.getAndIncrement()))
             .forEach(file -> uploadFile(savedPost, file));
 
@@ -157,13 +158,13 @@ public class PostServiceImpl implements PostService {
                 .collect(Collectors.toList()));
     }
 
-    private String uploadFile(Post post, ImageFile file) {
-        return postImageRepository.save(
+    private void uploadFile(Post post, ImageFile file) {
+        postImageRepository.save(
             PostImage.builder()
                 .post(post)
                 .imagePath(imageUpload.upload(file))
                 .build()
-        ).getImagePath();
+        );
     }
 
     private Post checkPostWriter(Long postId, String loginUser) {

--- a/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
@@ -42,16 +42,16 @@ public class UserController {
     }
 
     @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponse<UserResponse.Basic>> signUp(
+    public ResponseEntity<SuccessResponse<Long>> signUp(
         @ModelAttribute @Valid UserRequest.Save request) {
-        UserResponse.Basic response = userService.save(request);
+        Long createdUserId = userService.save(request);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{id}")
-            .buildAndExpand(response.id())
+            .buildAndExpand(createdUserId)
             .toUri();
 
         return ResponseEntity.created(location)
-            .body(new SuccessResponse<>(response));
+            .body(new SuccessResponse<>(createdUserId));
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
@@ -48,7 +48,7 @@ public class DefaultUserService implements UserService {
 
     @Override
     @Transactional
-    public UserResponse.Basic save(Save userRequest) {
+    public Long save(Save userRequest) {
         User user = userRepository.save(userConverter.saveToUser(userRequest));
 
         Optional.ofNullable(userRequest.profileImage())
@@ -61,7 +61,7 @@ public class DefaultUserService implements UserService {
                     })
             );
 
-        return userConverter.convertToUserResponseBasic(user);
+        return user.getId();
     }
 
     @Override

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
@@ -4,12 +4,11 @@ import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
 import com.devcourse.eggmarket.domain.user.model.User;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface UserService extends UserDetailsService {
 
-    UserResponse.Basic save(UserRequest.Save userRequest);
+    Long save(UserRequest.Save userRequest);
 
     UserResponse.Basic getByUsername(String userName);
 

--- a/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
@@ -1,13 +1,12 @@
 package com.devcourse.eggmarket.domain.user.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
-import javax.servlet.http.HttpSession;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,9 +16,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-
-import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 class DefaultUserServiceTest {
@@ -59,22 +55,15 @@ class DefaultUserServiceTest {
             .role("USER")
             .build();
 
-        UserResponse.Basic expectResponse = UserResponse.Basic.builder()
-            .nickName(newUser.getNickName())
-            .mannerTemperature(36.5F)
-            .role(newUser.getRole().toString())
-            .build();
-
         UserRequest.Save saveRequest = new UserRequest.Save(newUser.getPhoneNumber(),
             newUser.getNickName(), newUser.getPassword(), false, null);
 
         //When
-        UserResponse.Basic result = userService.save(saveRequest);
+        Long result = userService.save(saveRequest);
 
         //Then
-        assertThat(result).usingRecursiveComparison().ignoringFields("id")
-            .isEqualTo(expectResponse);
-
+        assertThat(userRepository.findById(result).isPresent())
+            .isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 이미지 업로드 로직 변경
    - 프로필 이미지 업로드 로직을 비동기화하였습니다. 회원 가입의 경우에는 프로필 이미지는 저장 실패하더라도 회원가입 처리 되는 것이 중요하기 때문입니다.
        - 이 때, 실패시 로그를 출력해주고 싶어도, 비동기 로직이 실행되는 스레드에서 발생하는 예외는 ControllerAdvice 에서 처리할 수 없습니다
            - 따라서 UserService 계층에서 로거를 통해 로그를 출력하도록 하였습니다 (어떻게 깔끔하게 할지 모르겠습니다..)
            ![image](https://user-images.githubusercontent.com/53856184/177328970-8afe33c8-9bdf-4ee1-a133-f6e0a3e1998c.png)

    - 포스트 이미지 업로드 로직 변경 :
      이런 상황이었습니다.
    - ![image](https://user-images.githubusercontent.com/53856184/177326858-88c976dc-d0db-4f0b-930a-bf281dbbc27e.png)

      value 에 아무것도 전달하지 않았다고 생각했는데, 멀티파트 구현체가 전달되어오는 상황이었습니다. 사실상 포스트 이미지를 등록하지 않은 상황으로 볼 수 있기 때문에, 이 경우에는 포스트 작성이 실패해서는 안됨에도 불구하고, 로직상 실패하고 있었습니다. 
      - 따라서 이를 해결하기 위해 필터링 로직을 추가하였습니다 ( fix 커밋이었어야 했겠네요 ㅠ-ㅠ)
- 회원가입시 Long 타입을 반환하는 것으로 변경하였습니다.
  - 다른 엔티티들과 마찬가지로 , 새로운 엔티티를 생성하여 저장할 경우 Long 타입 반환으로 변경하였습니다. 
  - save 결과가 Long 타입으로 변경되다보니 기존 테스트들이 유효하지 않아 이를 변경하였습니다. 

## 작업으로 인해 해결된 이슈 번호
- EM-78