### PR TITLE
 ♻️ refactor : 업로드 유저 프로필 이미지 변경과 유저 정보 변경 분리 및 구현

### DIFF
--- a/src/main/asciidoc/user-api.adoc
+++ b/src/main/asciidoc/user-api.adoc
@@ -78,7 +78,7 @@ include::{snippets}/user-change-password/response-fields.adoc[]
 
 == 사용자 정보 변경
 
-=== PUT /users
+=== PUT /users/profile
 
 .Request
 include::{snippets}/user-update/http-request.adoc[]
@@ -87,6 +87,19 @@ include::{snippets}/user-update/request-fields.adoc[]
 .Response
 include::{snippets}/user-update/http-response.adoc[]
 include::{snippets}/user-update/response-fields.adoc[]
+
+
+== 유저 프로필 변경
+
+=== POST /users/profile/image
+
+.Request
+include::{snippets}/user-update-profile/http-request.adoc[]
+include::{snippets}/user-update-profile/request-parts.adoc[]
+
+.Response
+include::{snippets}/user-update-profile/http-response.adoc[]
+include::{snippets}/user-update-profile/response-fields.adoc[]
 
 == 사용자 매너온도 조회
 
@@ -99,3 +112,4 @@ include::{snippets}/user-get-temperature/path-parameters.adoc[]
 .Response
 include::{snippets}/user-get-temperature/http-response.adoc[]
 include::{snippets}/user-get-temperature/response-fields.adoc[]
+

--- a/src/main/asciidoc/user-api.adoc
+++ b/src/main/asciidoc/user-api.adoc
@@ -91,7 +91,7 @@ include::{snippets}/user-update/response-fields.adoc[]
 
 == 유저 프로필 변경
 
-=== POST /user/profile/image
+=== POST /user/profile
 
 .Request
 include::{snippets}/user-update-profile/http-request.adoc[]

--- a/src/main/asciidoc/user-api.adoc
+++ b/src/main/asciidoc/user-api.adoc
@@ -32,7 +32,7 @@ include::{snippets}/user-login/response-fields.adoc[]
 
 == 로그아웃
 
-=== POST /login
+=== POST /logout
 
 .Request
 include::{snippets}/user-logout/http-request.adoc[]
@@ -41,9 +41,9 @@ include::{snippets}/user-logout/http-request.adoc[]
 include::{snippets}/user-logout/http-response.adoc[]
 
 
-== 로그아웃
+== 회원탈퇴
 
-=== POST /login
+=== POST /signout
 
 .Request
 include::{snippets}/user-signout/http-request.adoc[]
@@ -54,7 +54,7 @@ include::{snippets}/user-signout/response-fields.adoc[]
 
 == 로그인 ID 찾기
 
-=== POST /users/nickName
+=== POST /user/nickName
 
 .Request
 include::{snippets}/user-findName/http-request.adoc[]
@@ -66,7 +66,7 @@ include::{snippets}/user-findName/response-fields.adoc[]
 
 == 패스워드 변경
 
-=== PATCH /users/password
+=== PATCH /user/password
 
 .Request
 include::{snippets}/user-change-password/http-request.adoc[]
@@ -78,7 +78,7 @@ include::{snippets}/user-change-password/response-fields.adoc[]
 
 == 사용자 정보 변경
 
-=== PUT /users/profile
+=== PUT /user/profile
 
 .Request
 include::{snippets}/user-update/http-request.adoc[]
@@ -91,7 +91,7 @@ include::{snippets}/user-update/response-fields.adoc[]
 
 == 유저 프로필 변경
 
-=== POST /users/profile/image
+=== POST /user/profile/image
 
 .Request
 include::{snippets}/user-update-profile/http-request.adoc[]
@@ -101,15 +101,15 @@ include::{snippets}/user-update-profile/request-parts.adoc[]
 include::{snippets}/user-update-profile/http-response.adoc[]
 include::{snippets}/user-update-profile/response-fields.adoc[]
 
-== 사용자 매너온도 조회
+== 사용자 간단 조회
 
-=== GET /users/mannerTemperature/{id}
+=== GET /users/{id}/simple
 
 .Request
-include::{snippets}/user-get-temperature/http-request.adoc[]
+include::{snippets}/user-get-simple/http-request.adoc[]
 include::{snippets}/user-get-temperature/path-parameters.adoc[]
 
 .Response
-include::{snippets}/user-get-temperature/http-response.adoc[]
-include::{snippets}/user-get-temperature/response-fields.adoc[]
+include::{snippets}/user-get-simple/http-response.adoc[]
+include::{snippets}/user-get-simple/response-fields.adoc[]
 

--- a/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
@@ -142,7 +142,7 @@ public class UserController {
             new SuccessResponse<>(userService.updateUserInfo(user, userRequest)));
     }
 
-    @PostMapping(value = "/user/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/user/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<Long>> updateProfile(
         HttpServletRequest request,
         Authentication authentication,
@@ -150,10 +150,13 @@ public class UserController {
     ) {
         User user = userService.getUser(authentication.getName());
 
-        UserResponse.UpdateProfile response = userService.updateUserProfile(user, profile.image());
+        UserResponse.UpdateProfile response = userService.updateUserProfile(user, profile);
+        String filename = response.imagePath().substring(
+            response.imagePath().lastIndexOf("/") + 1
+        );
         final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{image}")
-            .buildAndExpand(response.imagePath())
+            .buildAndExpand(filename)
             .toUri();
         return ResponseEntity.created(location)
             .body(

--- a/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
     public ResponseEntity<SuccessResponse<Long>> signUp(
         @ModelAttribute @Valid UserRequest.Save request) {
         Long createdUserId = userService.save(request);
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{id}")
             .buildAndExpand(createdUserId)
             .toUri();
@@ -126,9 +126,9 @@ public class UserController {
             securityContext);
     }
 
-    @PutMapping("/users")
-    public ResponseEntity<SuccessResponse<UserResponse.Update>> update(HttpServletRequest
-        request,
+    @PutMapping(value = "/users/profile")
+    public ResponseEntity<SuccessResponse<Long>> updateUserInfo(
+        HttpServletRequest request,
         Authentication authentication,
         @RequestBody @Valid UserRequest.Update userRequest) {
         User user = userService.getUser(authentication.getName());
@@ -139,7 +139,28 @@ public class UserController {
         createNewSession(request, userDetails, securityContext);
 
         return ResponseEntity.ok(
-            new SuccessResponse<>(userService.update(user, userRequest)));
+            new SuccessResponse<>(userService.updateUserInfo(user, userRequest)));
+    }
+
+    @PostMapping(value = "/users/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponse<Long>> updateProfile(
+        HttpServletRequest request,
+        Authentication authentication,
+        @ModelAttribute UserRequest.Profile profile
+    ) {
+        User user = userService.getUser(authentication.getName());
+
+        UserResponse.UpdateProfile response = userService.updateUserProfile(user, profile.image());
+        final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{image}")
+            .buildAndExpand(response.imagePath())
+            .toUri();
+        return ResponseEntity.created(location)
+            .body(
+                new SuccessResponse<>(
+                    response.id()
+                )
+            );
     }
 
     @GetMapping("/users/mannerTemperature/{id}")

--- a/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/controller/UserController.java
@@ -87,7 +87,7 @@ public class UserController {
         }
     }
 
-    @GetMapping(value = "/users/nickname", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @GetMapping(value = "/user/nickname", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ResponseEntity<SuccessResponse<UserResponse.FindNickName>> findNickname(
         @ModelAttribute @Valid UserRequest.FindNickname userRequest) {
         return ResponseEntity.ok(
@@ -98,7 +98,7 @@ public class UserController {
     }
 
 
-    @PatchMapping("/users/password")
+    @PatchMapping("/user/password")
     public ResponseEntity<SuccessResponse<Boolean>> changePassword(HttpServletRequest request,
         Authentication authentication,
         @RequestBody UserRequest.ChangePassword userRequest) {
@@ -126,7 +126,7 @@ public class UserController {
             securityContext);
     }
 
-    @PutMapping(value = "/users/profile")
+    @PutMapping( "/user/profile")
     public ResponseEntity<SuccessResponse<Long>> updateUserInfo(
         HttpServletRequest request,
         Authentication authentication,
@@ -142,7 +142,7 @@ public class UserController {
             new SuccessResponse<>(userService.updateUserInfo(user, userRequest)));
     }
 
-    @PostMapping(value = "/users/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/user/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<Long>> updateProfile(
         HttpServletRequest request,
         Authentication authentication,
@@ -163,12 +163,12 @@ public class UserController {
             );
     }
 
-    @GetMapping("/users/mannerTemperature/{id}")
-    public ResponseEntity<SuccessResponse<UserResponse.MannerTemperature>> getMannerTemperature
+    @GetMapping("/users/{id}/simple")
+    public ResponseEntity<SuccessResponse<UserResponse.Simple>> getUserBySimple
         (
             @PathVariable Long id) {
         return ResponseEntity.ok(
-            new SuccessResponse<>(userService.getMannerTemperature(id)));
+            new SuccessResponse<>(userService.getUserBySimple(id)));
     }
 
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
@@ -3,6 +3,7 @@ package com.devcourse.eggmarket.domain.user.converter;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserConverter {
 
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     public UserConverter() {
         passwordEncoder = new BCryptPasswordEncoder();
@@ -42,19 +43,18 @@ public class UserConverter {
             .build();
     }
 
-    public UserResponse.Update convertToUpdate(User user) {
-        return UserResponse.Update.builder()
-            .id(user.getId())
-            .phoneNumber(user.getPhoneNumber())
-            .nickName(user.getNickName())
-            .build();
-    }
-
     public UserResponse.MannerTemperature convertToMannerTemp(User user) {
         return UserResponse.MannerTemperature.builder()
             .id(user.getId())
             .nickName(user.getNickName())
             .mannerTemperature(user.getMannerTemperature())
+            .build();
+    }
+
+    public UpdateProfile convertToUserUpdateProfile(User user) {
+        return UserResponse.UpdateProfile.builder()
+            .id(user.getId())
+            .imagePath(user.getImagePath())
             .build();
     }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/converter/UserConverter.java
@@ -2,7 +2,7 @@ package com.devcourse.eggmarket.domain.user.converter;
 
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
-import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,7 +27,7 @@ public class UserConverter {
             .build();
     }
 
-    public UserResponse.Basic convertToUserResponseBasic(User user) {
+    public UserResponse.Basic convertToBasic(User user) {
         return UserResponse.Basic.builder()
             .id(user.getId())
             .nickName(user.getNickName())
@@ -37,21 +37,21 @@ public class UserConverter {
             .build();
     }
 
-    public UserResponse.FindNickName convertToUserFindNickName(User user) {
+    public UserResponse.FindNickName convertToNickName(User user) {
         return UserResponse.FindNickName.builder()
             .nickName(user.getNickName())
             .build();
     }
 
-    public UserResponse.MannerTemperature convertToMannerTemp(User user) {
-        return UserResponse.MannerTemperature.builder()
+    public Simple convertToSimple(User user) {
+        return Simple.builder()
             .id(user.getId())
             .nickName(user.getNickName())
             .mannerTemperature(user.getMannerTemperature())
             .build();
     }
 
-    public UpdateProfile convertToUserUpdateProfile(User user) {
+    public UpdateProfile convertToUpdateProfile(User user) {
         return UserResponse.UpdateProfile.builder()
             .id(user.getId())
             .imagePath(user.getImagePath())

--- a/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserRequest.java
@@ -1,10 +1,10 @@
 package com.devcourse.eggmarket.domain.user.dto;
 
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
 public class UserRequest {
@@ -70,6 +70,13 @@ public class UserRequest {
         @NotBlank(message = "전화번호는 필수값입니다.")
         @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "잘못된 전화번호입니다.")
         String phoneNumber
+    ) {
+
+    }
+
+    public record Profile(
+        MultipartFile image
+
     ) {
 
     }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserResponse.java
@@ -26,17 +26,6 @@ public class UserResponse {
         }
     }
 
-    public record Update(
-        Long id,
-        String phoneNumber,
-        String nickName
-    ) {
-
-        @Builder
-        public Update {
-        }
-    }
-
     public record MannerTemperature(
         Long id,
         String nickName,
@@ -48,4 +37,14 @@ public class UserResponse {
         }
     }
 
+    public record UpdateProfile(
+        Long id,
+        String imagePath
+    ) {
+
+        @Builder
+        public UpdateProfile{
+
+        }
+    }
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/dto/UserResponse.java
@@ -26,14 +26,14 @@ public class UserResponse {
         }
     }
 
-    public record MannerTemperature(
+    public record Simple(
         Long id,
         String nickName,
         float mannerTemperature
     ) {
 
         @Builder
-        public MannerTemperature {
+        public Simple {
         }
     }
 

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
@@ -85,8 +85,8 @@ public class DefaultUserService implements UserService {
 
     @Override
     @Transactional
-    public UserResponse.UpdateProfile updateUserProfile(User user, MultipartFile profile) {
-        updateProfile(user, profile);
+    public UserResponse.UpdateProfile updateUserProfile(User user, UserRequest.Profile profile) {
+        updateProfile(user, profile.image());
         User updateUser = userRepository.save(user);
 
         return userConverter.convertToUpdateProfile(updateUser);
@@ -190,8 +190,10 @@ public class DefaultUserService implements UserService {
         if (profilePath != null) {
             imageUpload.deleteFile(profilePath);
         }
-        imageUpload.upload(
-            ProfileImageFile.toImage(user.getId(), profile)
+        user.setImagePath(
+            imageUpload.upload(
+                ProfileImageFile.toImage(user.getId(), profile)
+            )
         );
     }
 

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/DefaultUserService.java
@@ -10,7 +10,7 @@ import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.FindNickName;
-import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.exception.NotExistUserException;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
@@ -71,7 +71,7 @@ public class DefaultUserService implements UserService {
             throw new NotExistUserException();
         }
 
-        return userConverter.convertToUserResponseBasic(user.get());
+        return userConverter.convertToBasic(user.get());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class DefaultUserService implements UserService {
         updateProfile(user, profile);
         User updateUser = userRepository.save(user);
 
-        return userConverter.convertToUserUpdateProfile(updateUser);
+        return userConverter.convertToUpdateProfile(updateUser);
     }
 
 
@@ -122,7 +122,7 @@ public class DefaultUserService implements UserService {
             throw new NoSuchElementException("해당 핸드폰 번호를 가진 유저는 존재하지 않습니다.");
         }
 
-        return userConverter.convertToUserFindNickName(foundUser.get());
+        return userConverter.convertToNickName(foundUser.get());
     }
 
     @Override
@@ -145,10 +145,10 @@ public class DefaultUserService implements UserService {
     }
 
     @Override
-    public MannerTemperature getMannerTemperature(Long userId) {
+    public Simple getUserBySimple(Long userId) {
         User user = getUserById(userId);
 
-        return userConverter.convertToMannerTemp(user);
+        return userConverter.convertToSimple(user);
     }
 
     @Override

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
@@ -1,18 +1,20 @@
 package com.devcourse.eggmarket.domain.user.service;
 
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
+import com.devcourse.eggmarket.domain.user.dto.UserRequest.Profile;
+import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService extends UserDetailsService {
 
     Long save(UserRequest.Save userRequest);
 
     UserResponse.Basic getByUsername(String userName);
-
-    UserResponse.Update update(User user, UserRequest.Update userRequest);
 
     User getById(Long userId);
 
@@ -27,4 +29,8 @@ public interface UserService extends UserDetailsService {
     User getUserById(Long userId);
 
     MannerTemperature getMannerTemperature(Long userId);
+
+    Long updateUserInfo(User user, Update userRequest);
+
+    UserResponse.UpdateProfile updateUserProfile(User user, MultipartFile profile);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
@@ -30,5 +30,5 @@ public interface UserService extends UserDetailsService {
 
     Long updateUserInfo(User user, Update userRequest);
 
-    UserResponse.UpdateProfile updateUserProfile(User user, MultipartFile profile);
+    UserResponse.UpdateProfile updateUserProfile(User user, UserRequest.Profile profile);
 }

--- a/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/user/service/UserService.java
@@ -1,11 +1,9 @@
 package com.devcourse.eggmarket.domain.user.service;
 
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
-import com.devcourse.eggmarket.domain.user.dto.UserRequest.Profile;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
-import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
-import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +26,7 @@ public interface UserService extends UserDetailsService {
 
     User getUserById(Long userId);
 
-    MannerTemperature getMannerTemperature(Long userId);
+    Simple getUserBySimple(Long userId);
 
     Long updateUserInfo(User user, Update userRequest);
 

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -140,12 +140,12 @@ class PostServiceIntegrationTest {
 
         postImageRepository.save(PostImage.builder()
             .post(likedPost1)
-            .imagePath(ImageStub.image1(likedPost1.getId()).pathTobeStored(""))
+            .imagePath(ImageStub.uploadImage1(likedPost1.getId()).pathTobeStored(""))
             .build()
         );
         postImageRepository.save(PostImage.builder()
             .post(likedPost1)
-            .imagePath(ImageStub.image2(likedPost1.getId()).pathTobeStored(""))
+            .imagePath(ImageStub.uploadImage2(likedPost1.getId()).pathTobeStored(""))
             .build()
         );
         commentRepository.save(comment1);

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/ImageStub.java
@@ -4,15 +4,24 @@ import com.devcourse.eggmarket.domain.model.image.ImageFile;
 import com.devcourse.eggmarket.domain.model.image.PostImageFile;
 import java.nio.charset.StandardCharsets;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 public class ImageStub {
 
     private ImageStub() {
     }
 
-    private static final String mockImage = "mock";
+    private static final String mockImage = "image";
 
-    public static ImageFile image1(Long postId) {
+    public static MockMultipartFile image1() {
+        return new MockMultipartFile(
+            "image",
+            "img.png",
+            "image/png",
+            mockImage.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+    public static ImageFile uploadImage1(Long postId) {
         return PostImageFile.toImage(postId, new MockMultipartFile("image1",
             "1.png",
             "image/png",
@@ -21,7 +30,7 @@ public class ImageStub {
 
     }
 
-    public static ImageFile image2(Long postId) {
+    public static ImageFile uploadImage2(Long postId) {
         return PostImageFile.toImage(postId,
             new MockMultipartFile("image2",
                 "2.png",

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/PostStub.java
@@ -97,8 +97,8 @@ public class PostStub {
             1,
             1,
             true,
-            List.of(ImageStub.image1(post.getId()).pathTobeStored(""),
-                ImageStub.image2(post.getId()).pathTobeStored(""))
+            List.of(ImageStub.uploadImage1(post.getId()).pathTobeStored(""),
+                ImageStub.uploadImage2(post.getId()).pathTobeStored(""))
         );
     }
 

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
@@ -5,7 +5,7 @@ import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.Basic;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.FindNickName;
-import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.model.UserRole;
@@ -68,8 +68,8 @@ public class UserStub {
         return new FindNickName(user.getNickName());
     }
 
-    public static MannerTemperature temperatureResponse(User user) {
-        return MannerTemperature.builder()
+    public static Simple simpleResponse(User user) {
+        return Simple.builder()
             .id(user.getId())
             .nickName(user.getNickName())
             .mannerTemperature(user.getMannerTemperature())

--- a/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/stub/UserStub.java
@@ -1,5 +1,12 @@
 package com.devcourse.eggmarket.domain.stub;
 
+import com.devcourse.eggmarket.domain.user.dto.UserRequest;
+import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Basic;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.FindNickName;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.MannerTemperature;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.model.UserRole;
 
@@ -26,5 +33,53 @@ public class UserStub {
             36.5F,
             null,
             UserRole.USER);
+    }
+
+    public static User imagePathEntity() {
+        return new User(2L,
+            "010-2234-5678",
+            "tests",
+            "test1234!@#$s",
+            36.5F,
+            "http://example.com/profile/2.png",
+            UserRole.USER);
+    }
+    public static Save saveRequest() {
+        return new UserRequest.Save(
+            "010-1234-5678",
+            "test",
+            "test1234!@#$",
+            false,
+            null
+        );
+    }
+
+    public static Basic basicResponse(User user) {
+        return UserResponse.Basic.builder()
+            .id(user.getId())
+            .nickName(user.getNickName())
+            .imagePath(user.getImagePath())
+            .role(String.valueOf(user.getRole()))
+            .mannerTemperature(user.getMannerTemperature())
+            .build();
+    }
+
+    public static FindNickName nickNameResponse(User user) {
+        return new FindNickName(user.getNickName());
+    }
+
+    public static MannerTemperature temperatureResponse(User user) {
+        return MannerTemperature.builder()
+            .id(user.getId())
+            .nickName(user.getNickName())
+            .mannerTemperature(user.getMannerTemperature())
+            .build();
+    }
+
+    public static UpdateProfile updateProfileResponse(User user) {
+        return UserResponse.UpdateProfile.builder()
+            .id(user.getId())
+            .imagePath(user.getImagePath())
+            .build();
     }
 }

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -407,7 +407,7 @@ class UserControllerTest {
 
         MockMultipartFile image = ImageStub.image1();
         MvcResult result = mockMvc.perform(
-                multipart("/user/profile/image")
+                multipart("/user/profile")
                     .file(image)
             )
             .andExpect(status().isCreated())

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -19,8 +19,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.devcourse.eggmarket.domain.model.image.ImageFile;
+import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.FindNickname;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
@@ -35,7 +38,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -103,6 +108,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("회원가입 기능 테스트")
     void signUp() throws Exception {
         //Given
         User newUser = User.builder()
@@ -161,6 +167,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("로그인 기능 테스트")
     void login() throws Exception {
         //Given
         UserResponse.Basic expectResponse = UserResponse.Basic.builder()
@@ -200,6 +207,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("로그아웃 기능 테스트")
     void logoutTest() throws Exception {
         SecurityContext securityContext = SecurityContextHolder.getContext();
         UserDetails userDetails = userService.loadUserByUsername(user.getNickName());
@@ -223,6 +231,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("회원 탈퇴 기능 테스트")
     void signOut() throws Exception {
         //Given
         SecurityContext securityContext = SecurityContextHolder.getContext();
@@ -259,6 +268,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("닉네임으로 회원정보 불러오기")
     void getUserName() throws Exception {
         //Given
         SuccessResponse<UserResponse.FindNickName> expectResult = new SuccessResponse<>(
@@ -294,6 +304,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("비밀번호 변경 테스트")
     void changePassword() throws Exception {
         //Given
         SecurityContext securityContext = SecurityContextHolder.getContext();
@@ -336,9 +347,9 @@ class UserControllerTest {
         assertThat(updateResult).usingRecursiveComparison().isEqualTo(response);
     }
 
-    // TODO 업데이트시 이미지 받을 수 있도록 수정해야함
     @Test
-    void update() throws Exception {
+    @DisplayName("유저 정보 변경 테스트")
+    void updateUserInfoTest() throws Exception {
         //Given
         SecurityContext securityContext = SecurityContextHolder.getContext();
         UserDetails userDetails = userService.loadUserByUsername(user.getNickName());
@@ -350,13 +361,11 @@ class UserControllerTest {
             securityContext);
 
         UserRequest.Update userRequest = new Update("010-1111-1111", "updateNick");
-        SuccessResponse<UserResponse.Update> expectResponse = new SuccessResponse<>(
-            new UserResponse.Update(userIdResponse,
-                userRequest.phoneNumber(), userRequest.nickName()));
+        SuccessResponse<Long> expectResponse = new SuccessResponse<>(userIdResponse);
 
         //When
         MvcResult result = mockMvc.perform(
-                put("/users")
+                put("/users/profile")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(userRequest))
             )
@@ -369,15 +378,12 @@ class UserControllerTest {
                     fieldWithPath("nickName").type(JsonFieldType.STRING).description("닉네임")
                 ),
                 responseFields(
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 ID"),
-                    fieldWithPath("data.phoneNumber").type(JsonFieldType.STRING)
-                        .description("전화번호"),
-                    fieldWithPath("data.nickName").type(JsonFieldType.STRING).description("닉네임")
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("유저 ID")
                 )
             ))
             .andReturn();
 
-        SuccessResponse<UserResponse.Update> updateResult = objectMapper
+        SuccessResponse<Long> updateResult = objectMapper
             .readValue(result.getResponse().getContentAsString(),
                 new TypeReference<>() {
                 });
@@ -389,6 +395,39 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("유저 프로필 이미지 변경 테스트")
+    void updateProfileTest() throws Exception {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        UserDetails userDetails = userService.loadUserByUsername(user.getNickName());
+        securityContext.setAuthentication(
+            new UsernamePasswordAuthenticationToken(userDetails, null,
+                userDetails.getAuthorities()));
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+            securityContext);
+
+        MockMultipartFile image = ImageStub.image1();
+        MvcResult result = mockMvc.perform(
+                multipart("/users/profile/image")
+                    .file(image)
+            )
+            .andExpect(status().isCreated())
+            .andDo(document("user-update-profile",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestParts(
+                    partWithName("image").description("유저 프로필 이미지")
+                ),
+                responseFields(
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("유저 ID")
+                )
+            ))
+            .andReturn();
+
+    }
+
+    @Test
+    @DisplayName("")
     void getMannerTemperature() throws Exception {
         //Given
         SuccessResponse<UserResponse.MannerTemperature> expectResponse = new SuccessResponse<>(

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -119,7 +119,7 @@ class UserControllerTest {
             .build();
 
         SuccessResponse<Long> expectResponse =
-            new SuccessResponse<>(user.getId());
+            new SuccessResponse<>(userIdResponse + 1);
 
         UserRequest.Save saveRequest = new UserRequest.Save(
             newUser.getPhoneNumber(),

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -22,13 +22,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.devcourse.eggmarket.domain.model.image.ImageFile;
 import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.FindNickname;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Save;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
 import com.devcourse.eggmarket.domain.user.service.UserService;
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -278,7 +277,7 @@ class UserControllerTest {
         UserRequest.FindNickname request = new FindNickname(user.getPhoneNumber());
         //When
         MvcResult result = mockMvc.perform(
-                get("/users/nickname")
+                get("/user/nickname")
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                     .param("phoneNumber", request.phoneNumber()))
             .andExpect(status().isOk())
@@ -321,7 +320,7 @@ class UserControllerTest {
         );
 
         //When
-        MvcResult result = mockMvc.perform(patch("/users/password")
+        MvcResult result = mockMvc.perform(patch("/user/password")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userRequest)))
             .andExpect(status().isOk())
@@ -365,7 +364,7 @@ class UserControllerTest {
 
         //When
         MvcResult result = mockMvc.perform(
-                put("/users/profile")
+                put("/user/profile")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(userRequest))
             )
@@ -408,7 +407,7 @@ class UserControllerTest {
 
         MockMultipartFile image = ImageStub.image1();
         MvcResult result = mockMvc.perform(
-                multipart("/users/profile/image")
+                multipart("/user/profile/image")
                     .file(image)
             )
             .andExpect(status().isCreated())
@@ -427,11 +426,11 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("")
-    void getMannerTemperature() throws Exception {
+    @DisplayName("유저 간단 정보 조회")
+    void getUserBySimpleTest() throws Exception {
         //Given
-        SuccessResponse<UserResponse.MannerTemperature> expectResponse = new SuccessResponse<>(
-            UserResponse.MannerTemperature.builder()
+        SuccessResponse<Simple> expectResponse = new SuccessResponse<>(
+            Simple.builder()
                 .id(userIdResponse)
                 .nickName(user.getNickName())
                 .mannerTemperature(user.getMannerTemperature())
@@ -440,10 +439,10 @@ class UserControllerTest {
 
         //When
         MvcResult result = mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/users/mannerTemperature/{id}",
+                RestDocumentationRequestBuilders.get("/users/{id}/simple",
                     userIdResponse))
             .andExpect(status().isOk())
-            .andDo(document("user-get-temperature",
+            .andDo(document("user-get-simple",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 pathParameters(
@@ -458,7 +457,7 @@ class UserControllerTest {
             ))
             .andReturn();
 
-        SuccessResponse<UserResponse.MannerTemperature> mannerTempResult = objectMapper
+        SuccessResponse<Simple> mannerTempResult = objectMapper
             .readValue(result.getResponse().getContentAsString(),
                 new TypeReference<>() {
                 });

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -119,7 +119,7 @@ class UserControllerTest {
             .build();
 
         SuccessResponse<Long> expectResponse =
-            new SuccessResponse<>(2L);
+            new SuccessResponse<>(user.getId());
 
         UserRequest.Save saveRequest = new UserRequest.Save(
             newUser.getPhoneNumber(),

--- a/src/test/java/com/devcourse/eggmarket/domain/user/converter/UserConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/converter/UserConverterTest.java
@@ -1,0 +1,79 @@
+package com.devcourse.eggmarket.domain.user.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.devcourse.eggmarket.domain.stub.UserStub;
+import com.devcourse.eggmarket.domain.user.dto.UserRequest;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import com.devcourse.eggmarket.domain.user.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class UserConverterTest {
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    private final UserConverter userConverter = new UserConverter();
+
+    @Test
+    @DisplayName("UserRequest.save -> User entity 변환 테스트")
+    void saveToUserTest() {
+        UserRequest.Save request = UserStub.saveRequest();
+        User want = UserStub.entity();
+
+        User got = userConverter.saveToUser(request);
+
+        assertThat(got)
+            .usingRecursiveComparison()
+            .ignoringFields("id")
+            .ignoringFields("password")
+            .isEqualTo(want);
+        assertThat(passwordEncoder.matches(want.getPassword(), got.getPassword())).isTrue();
+    }
+
+    @Test
+    @DisplayName("User -> UserResponse.Basic 변환 테스트")
+    void convertToUserResponseBasicTest() {
+        User request = UserStub.entity();
+        UserResponse.Basic want = UserStub.basicResponse(request);
+
+        UserResponse.Basic got = userConverter.convertToUserResponseBasic(request);
+
+        assertThat(got).usingRecursiveComparison().isEqualTo(want);
+    }
+
+    @Test
+    @DisplayName("User -> UserResponse.findNickName 변환 테스트")
+    void convertToUserFindNickNameTest() {
+        User request = UserStub.entity();
+        UserResponse.FindNickName want = UserStub.nickNameResponse(request);
+
+        UserResponse.FindNickName got = userConverter.convertToUserFindNickName(request);
+
+        assertThat(got).usingRecursiveComparison().isEqualTo(want);
+    }
+
+    @Test
+    @DisplayName("User -> UserResponse.MannerTemperature 변환 테스트")
+    void convertToMannerTemp() {
+        User request = UserStub.entity();
+        UserResponse.MannerTemperature want = UserStub.temperatureResponse(request);
+
+        UserResponse.MannerTemperature got = userConverter.convertToMannerTemp(request);
+
+        assertThat(got).usingRecursiveComparison().isEqualTo(want);
+    }
+
+    @Test
+    @DisplayName("User -> UserResponse.UpdateProfile 변환 테스트")
+    void convertToUserUpdateProfileTest() {
+        User request = UserStub.imagePathEntity();
+        UserResponse.UpdateProfile want = UserStub.updateProfileResponse(request);
+
+        UserResponse.UpdateProfile got = userConverter.convertToUserUpdateProfile(request);
+
+        assertThat(got).usingRecursiveComparison().isEqualTo(want);
+    }
+}

--- a/src/test/java/com/devcourse/eggmarket/domain/user/converter/UserConverterTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/converter/UserConverterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.devcourse.eggmarket.domain.stub.UserStub;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.model.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,40 +40,40 @@ class UserConverterTest {
         User request = UserStub.entity();
         UserResponse.Basic want = UserStub.basicResponse(request);
 
-        UserResponse.Basic got = userConverter.convertToUserResponseBasic(request);
+        UserResponse.Basic got = userConverter.convertToBasic(request);
 
         assertThat(got).usingRecursiveComparison().isEqualTo(want);
     }
 
     @Test
-    @DisplayName("User -> UserResponse.findNickName 변환 테스트")
-    void convertToUserFindNickNameTest() {
+    @DisplayName("User -> UserResponse.FindNickName 변환 테스트")
+    void convertToNickNameTest() {
         User request = UserStub.entity();
         UserResponse.FindNickName want = UserStub.nickNameResponse(request);
 
-        UserResponse.FindNickName got = userConverter.convertToUserFindNickName(request);
+        UserResponse.FindNickName got = userConverter.convertToNickName(request);
 
         assertThat(got).usingRecursiveComparison().isEqualTo(want);
     }
 
     @Test
-    @DisplayName("User -> UserResponse.MannerTemperature 변환 테스트")
-    void convertToMannerTemp() {
+    @DisplayName("User -> UserResponse.Simple 변환 테스트")
+    void convertToSimpleTest() {
         User request = UserStub.entity();
-        UserResponse.MannerTemperature want = UserStub.temperatureResponse(request);
+        Simple want = UserStub.simpleResponse(request);
 
-        UserResponse.MannerTemperature got = userConverter.convertToMannerTemp(request);
+        Simple got = userConverter.convertToSimple(request);
 
         assertThat(got).usingRecursiveComparison().isEqualTo(want);
     }
 
     @Test
     @DisplayName("User -> UserResponse.UpdateProfile 변환 테스트")
-    void convertToUserUpdateProfileTest() {
+    void convertToUpdateProfileTest() {
         User request = UserStub.imagePathEntity();
         UserResponse.UpdateProfile want = UserStub.updateProfileResponse(request);
 
-        UserResponse.UpdateProfile got = userConverter.convertToUserUpdateProfile(request);
+        UserResponse.UpdateProfile got = userConverter.convertToUpdateProfile(request);
 
         assertThat(got).usingRecursiveComparison().isEqualTo(want);
     }

--- a/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
@@ -84,14 +84,13 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void update() {
+    void updateUserInfoTest() {
         //Given
         UserRequest.Update userRequest = new Update("01011111111", "updateNick");
-        UserResponse.Update expectResponse = new UserResponse.Update(user.getId(),
-            userRequest.phoneNumber(), userRequest.nickName());
+        Long expectResponse = user.getId();
 
         //When
-        UserResponse.Update result = userService.update(user, userRequest);
+        Long result = userService.updateUserInfo(user, userRequest);
 
         //Then
         assertThat(result).usingRecursiveComparison().isEqualTo(expectResponse);

--- a/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
@@ -5,10 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,7 +48,7 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void save() {
+    void saveTest() {
         //Given
         User newUser = User.builder()
             .nickName("test2")
@@ -62,12 +64,12 @@ class DefaultUserServiceTest {
         Long result = userService.save(saveRequest);
 
         //Then
-        assertThat(userRepository.findById(result).isPresent())
-            .isTrue();
+        assertThat(userRepository.findById(result))
+            .isPresent();
     }
 
     @Test
-    void getByUsername() {
+    void getByUsernameTest() {
         //Given
         UserResponse.Basic expectResponse = UserResponse.Basic.builder()
             .nickName(user.getNickName())
@@ -98,7 +100,8 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void getUser() {
+    @DisplayName("닉네임을 기준으로 유저 조회 테스트")
+    void getUserTest() {
         //When
         UserDetails userDetails = userService.loadUserByUsername(user.getNickName());
         SecurityContext securityContext = SecurityContextHolder.getContext();
@@ -113,7 +116,8 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void deleteById() {
+    @DisplayName("유저 아이디를 기준으로 삭제 테스트")
+    void deleteByIdTest() {
         //When
         Long userId = userService.delete(user);
 
@@ -122,7 +126,8 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void getUserName() {
+    @DisplayName("유저 닉네임 조회 기능 테스트")
+    void getUserNameTest() {
         //Given
         UserResponse.FindNickName expectResult = UserResponse.FindNickName.builder()
             .nickName(user.getNickName()).build();
@@ -135,7 +140,8 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void updatePassword() {
+    @DisplayName("패스워드 변경 테스트")
+    void updatePasswordTest() {
         //Given
         UserRequest.ChangePassword userRequest = new UserRequest.ChangePassword(
             "NewPass!1"
@@ -149,16 +155,17 @@ class DefaultUserServiceTest {
     }
 
     @Test
-    void getMannerTemperature() {
+    @DisplayName("유저 간단 조회 테스트")
+    void getUserBySimpleTest() {
         //Given
-        UserResponse.MannerTemperature expectResponse = UserResponse.MannerTemperature.builder()
+        Simple expectResponse = Simple.builder()
             .id(user.getId())
             .nickName(user.getNickName())
             .mannerTemperature(user.getMannerTemperature())
             .build();
 
         //When
-        UserResponse.MannerTemperature result = userService.getMannerTemperature(user.getId());
+        Simple result = userService.getUserBySimple(user.getId());
 
         //Then
         assertThat(result).usingRecursiveComparison().isEqualTo(expectResponse);

--- a/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
@@ -2,10 +2,13 @@ package com.devcourse.eggmarket.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.devcourse.eggmarket.domain.stub.ImageStub;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest;
+import com.devcourse.eggmarket.domain.user.dto.UserRequest.Profile;
 import com.devcourse.eggmarket.domain.user.dto.UserRequest.Update;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse;
 import com.devcourse.eggmarket.domain.user.dto.UserResponse.Simple;
+import com.devcourse.eggmarket.domain.user.dto.UserResponse.UpdateProfile;
 import com.devcourse.eggmarket.domain.user.model.User;
 import com.devcourse.eggmarket.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -48,6 +51,7 @@ class DefaultUserServiceTest {
     }
 
     @Test
+    @DisplayName("유저 정보 DB 저장 테스트")
     void saveTest() {
         //Given
         User newUser = User.builder()
@@ -69,6 +73,7 @@ class DefaultUserServiceTest {
     }
 
     @Test
+    @DisplayName("유저 정보 조회 테스트")
     void getByUsernameTest() {
         //Given
         UserResponse.Basic expectResponse = UserResponse.Basic.builder()
@@ -86,6 +91,7 @@ class DefaultUserServiceTest {
     }
 
     @Test
+    @DisplayName("유저 정보만 변경 테스트")
     void updateUserInfoTest() {
         //Given
         UserRequest.Update userRequest = new Update("01011111111", "updateNick");
@@ -97,6 +103,19 @@ class DefaultUserServiceTest {
         //Then
         assertThat(result).usingRecursiveComparison().isEqualTo(expectResponse);
 
+    }
+
+    @Test
+    @DisplayName("유저 프로필 변경 테스트")
+    void updateUserProfileTest() {
+        UserRequest.Profile userRequest = new Profile(ImageStub.image1());
+        UserResponse.UpdateProfile expectResponse = UserResponse.UpdateProfile.builder()
+            .id(user.getId())
+            .build();
+
+        UserResponse.UpdateProfile result = userService.updateUserProfile(user, userRequest);
+
+        assertThat(result.id()).usingRecursiveComparison().isEqualTo(expectResponse.id());
     }
 
     @Test


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 프로필 이미지는 POST `/users/profile/image` 로 변경 (이미지 업로드에 사용하는 multipart/form-data가 GET, POST 지원)
- 유저 정보 변경은 PUT `/users/profile` 로 변경
- userConverter 테스트 코드 추가
- 유저 업데이트시 id 값만 반환하도록 변경
- 컨트롤러 테스트 추가 및 수정

## 이슈 번호
- EM-14