### PR TITLE
✨  feat : 판매글 삭제시 이미지도 삭제되는 로직 추가

### DIFF
--- a/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/devcourse/eggmarket/domain/post/service/PostServiceImpl.java
@@ -115,7 +115,9 @@ public class PostServiceImpl implements PostService {
     @Transactional
     @Override
     public void deleteById(Long id, String loginUser) {
-        checkPostWriter(id, loginUser);
+        Post post = checkPostWriter(id, loginUser);
+
+        removeFiles(post);
         postRepository.deleteById(id);
     }
 
@@ -183,6 +185,12 @@ public class PostServiceImpl implements PostService {
                 .imagePath(imageUpload.upload(file))
                 .build()
         );
+    }
+
+    private void removeFiles(Post post) {
+        postImageRepository.findAllByPost(post).stream()
+            .map(PostImage::getImagePath)
+            .forEach(imageUpload::deleteFile);
     }
 
     private Post checkPostWriter(Long postId, String loginUser) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -5,7 +5,7 @@ DROP TABLE IF EXISTS post_image;
 DROP TABLE IF EXISTS post;
 DROP TABLE IF EXISTS users;
 
-CREATE TABLE USERS
+CREATE TABLE users
 (
     id 						BIGINT AUTO_INCREMENT,
     phone_number 			VARCHAR(15)	NOT NULL UNIQUE,
@@ -20,7 +20,7 @@ CREATE TABLE USERS
     PRIMARY KEY(id)
 );
 
-CREATE TABLE Post
+CREATE TABLE post
 (
     id						BIGINT AUTO_INCREMENT,
     seller_id				BIGINT,
@@ -98,7 +98,7 @@ ALTER TABLE evaluation
 
 ALTER TABLE evaluation
     ADD CONSTRAINT evaluation_fk_post
-        FOREIGN KEY (post_id) REFERENCES users(id);
+        FOREIGN KEY (post_id) REFERENCES post(id);
 
 ALTER TABLE evaluation
     ADD CONSTRAINT evaluation_fk_reviewee_user

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceImplTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import com.devcourse.eggmarket.domain.comment.model.Comment;
 import com.devcourse.eggmarket.domain.comment.repository.CommentRepository;
+import com.devcourse.eggmarket.domain.model.image.ImageUpload;
 import com.devcourse.eggmarket.domain.post.converter.PostConverter;
 import com.devcourse.eggmarket.domain.post.dto.PostRequest;
 import com.devcourse.eggmarket.domain.post.dto.PostResponse;
@@ -67,6 +68,9 @@ class PostServiceImplTest {
 
     @Mock
     PostImageRepository postImageRepository;
+
+    @Mock
+    ImageUpload imageUpload;
 
     @Test
     @DisplayName("판매글 생성 테스트")


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 판매글 삭제시 이미지도 삭제되는 로직을 추가했습니다
- DDL 의 참조관계가 잘못되어있어 수정했습니다

## 작업으로 인해 해결된 이슈 번호
- EM-84