### PR TITLE
🔧 config : 서버용 프로파일 수정 및 테스트용 프로파일 생성

### DIFF
--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,15 +1,16 @@
 spring:
   config:
     activate:
-      on-profile: prod
-  sql:
-    init:
-      mode: always
+      on-profile: test
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   datasource:
-    driver-class-name: ${DB_DRIVER}
-    url: ${DB_URL}
-    username: ${DB_USER_NAME}
-    password: ${DB_PASSWORD}
+    driver-class-name: org.h2.Driver
+    url: "jdbc:h2:mem:egg_market;mode=mysql"
+    username: sa
+    password:
   jpa:
     open-in-view: false
     properties:

--- a/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/comment/repository/CommentRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/devcourse/eggmarket/domain/comment/service/CommentServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/comment/service/CommentServiceIntegrationTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CommentServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/api/PostControllerIntegrationTest.java
@@ -37,12 +37,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
 class PostControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/post/service/PostServiceIntegrationTest.java
@@ -28,8 +28,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PostServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/controller/UserControllerTest.java
@@ -54,12 +54,14 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @SpringBootTest
+@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
+++ b/src/test/java/com/devcourse/eggmarket/domain/user/service/DefaultUserServiceTest.java
@@ -21,8 +21,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DefaultUserServiceTest {
 
     @Autowired


### PR DESCRIPTION
## 🧑‍💻 작업사항
- 서버의 DB 드라이버, url, username, password와 같은 민감정보는 서버측의 환경변수로 저장
- 통합테스트의 경우 `@ActiveProfile`을 이용하여 테스트용 프로파일로 동작하도록 변경

## 이슈 번호
- EM-47